### PR TITLE
Verify staleness by reflection instead of inferring it from "did not report"

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -123,3 +123,65 @@ normally, just without TIA active for that run. Verified end-to-end in
 `fixture-app/`: with no driver, tests execute and pass; forcing past this
 check to isolate bug 1 reproduces the clean warning-event path with no
 crash, confirming the two fixes are independent and both necessary.
+
+---
+
+## Why staleness is verified by reflection, not inferred from "did not report"
+
+`WriteGraph::notify()` passes `$keepTestIds` — the IDs that produced a result
+this run — to `Graph::pruneStaleResults()`, which used to delete any baseline
+entry whose file was executed but whose ID was absent from that list. The
+inference is "the method must have been removed or renamed".
+
+That inference only holds for a **full** run of the file, and TIA's entire
+purpose is to make runs partial:
+
+- A test skipped by `RunWithTia` reports nothing at all. PHPUnit emits
+  `Test\Prepared` **after** `setUp()` — in `TestCase::runBare()` the order is
+  `HookMethodInvoker::invokeBeforeTest()` (which runs `setUp()`), then
+  `invokePreCondition()`, then `$emitter->testPrepared(...)`. Since `setUp()`
+  is the only hook the trait can skip from (see the first section of this
+  file), `markTestSkipped()` unwinds before `Prepared` fires,
+  `RecordTestPrepared` never runs, and `ResultCollector::record()` returns
+  early on its null-`$currentTestId` guard. The test's file is still
+  "touched", because the siblings TIA did *not* skip ran normally.
+- A `--filter`ed run reports only the selected methods, while their file
+  likewise counts as touched.
+
+So the heuristic deleted the cached pass of a live test. The consequence was
+self-defeating: TIA's evidence for skipping a test is its recorded pass, and
+its own skip destroyed that evidence. Next run the test had no cached
+success, so it executed for real and recorded a pass; the run after that
+skipped it and pruned it again.
+
+Measured on a 5,768-test Laravel suite with **zero** changes between runs, the
+graph oscillated on a deterministic two-cycle:
+
+| run | duration | skipped | graph.json |
+|-----|----------|---------|------------|
+| A   | 0:17     | 5,604   | 928K       |
+| B   | 2:16     | 3,555   | 1.5M       |
+| C   | 0:17     | 5,604   | 928K       |
+
+A **fully** skipped file pruned nothing (`$touched === []` returns early),
+which is why the suite oscillated rather than degrading monotonically.
+
+**Fix**: `pruneStaleResults()` now confirms absence directly —
+`Graph::testIsStillDefined()` splits the ID (`Class::method`, plus an optional
+`#<dataSetName>` suffix; a class name cannot contain `::` and a method name
+cannot contain `#`, so the first occurrence of each is the correct split
+point) and checks `class_exists()` + `method_exists()`. An unparseable ID, or
+one whose class no longer resolves, is still treated as gone — that is the
+pre-existing behaviour for a deleted test file, and keeping unresolvable
+entries forever would grow the baseline without bound.
+
+This also removes a misleading symptom: a partial run immediately followed by
+a second runner (e.g. paratest) would leave that runner almost nothing to
+replay, which reads as "TIA doesn't work with my runner" rather than as a
+pruning bug.
+
+Regression coverage lives at both levels — `GraphTest` for the unit
+behaviour (kept, kept-with-data-set, dropped-removed-method,
+dropped-unparseable-ID) and `WriteGraphTest` for the write path that produces
+the partial-run condition in the first place. All four `testIsStillDefined()`
+branches are exercised.

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -610,8 +610,28 @@ final class Graph
 
     /**
      * Prune baseline result entries whose test files were just executed but
-     * whose test IDs are no longer present (e.g. the test method was
+     * whose test IDs no longer exist in the codebase (e.g. the test method was
      * removed or renamed).
+     *
+     * "No longer exists" is verified by reflection rather than inferred from
+     * `$keepTestIds`. Absence from that list means "did not report a result
+     * this run", which is emphatically not the same thing as "was deleted"
+     * once the run is partial — and TIA's entire purpose is to make runs
+     * partial:
+     *
+     *  - A test skipped by {@see Traits\RunWithTia} never reports at all.
+     *    PHPUnit emits `Test\Prepared` *after* `setUp()`
+     *    (`TestCase::runBare()`), and `setUp()` is the only hook the trait can
+     *    skip from, so `ResultCollector` never sees the test. Its file is
+     *    still "touched" by whichever siblings did run.
+     *  - A `--filter`ed run reports only the selected methods, while their
+     *    file counts as touched.
+     *
+     * In both cases the old heuristic deleted the cached pass of a live test,
+     * so the next run had to execute it again — which recorded a pass, which
+     * got skipped, which got pruned. Left a suite with zero changes
+     * oscillating between mostly-skipped and mostly-re-run on alternate runs,
+     * and made the inner `--filter` loop quietly destructive.
      *
      * @param  array<int, string>  $touchedFiles  Absolute or project-relative paths.
      * @param  array<int, string>  $keepTestIds  Test IDs that produced a result this run.
@@ -645,8 +665,49 @@ final class Graph
                 continue;
             }
 
+            if (self::testIsStillDefined($testId)) {
+                continue;
+            }
+
             unset($this->baselines[$branch]['results'][$testId]);
         }
+    }
+
+    /**
+     * Is `$testId` still a real method on a real class?
+     *
+     * IDs look like `Fully\Qualified\ClassName::methodName`, with a
+     * `#<dataSetName>` suffix for data-provided tests (`TestMethod::id()`).
+     * A class name cannot contain `::` and a method name cannot contain `#`,
+     * so the first occurrence of each is the correct split point even when a
+     * data-set name contains either character.
+     *
+     * An ID we cannot parse, or whose class cannot be resolved, is reported as
+     * gone — that is the pre-existing behaviour for a deleted test file, and
+     * keeping unresolvable entries forever would grow the baseline without
+     * bound.
+     */
+    private static function testIsStillDefined(string $testId): bool
+    {
+        $separator = strpos($testId, '::');
+
+        if ($separator === false) {
+            return false;
+        }
+
+        $class = substr($testId, 0, $separator);
+        $method = substr($testId, $separator + 2);
+        $dataSet = strpos($method, '#');
+
+        if ($dataSet !== false) {
+            $method = substr($method, 0, $dataSet);
+        }
+
+        if (! class_exists($class)) {
+            return false;
+        }
+
+        return method_exists($class, $method);
     }
 
     public static function decode(string $json, string $projectRoot): ?self

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -259,6 +259,89 @@ final class GraphTest extends TestCase
         $this->assertNull($graph->getResult('main', 'Tests\\FooTest::old_method'));
     }
 
+    /**
+     * The regression this guards against is TIA defeating itself.
+     *
+     * PHPUnit emits `Test\Prepared` *after* `setUp()` (`TestCase::runBare()`),
+     * and `setUp()` is the only hook `RunWithTia` can skip from — so a test
+     * skipped by TIA never reports a result and is absent from
+     * `$keepTestIds`. Its file still counts as touched, because the siblings
+     * TIA did *not* skip ran normally. Treating "touched file + unseen ID" as
+     * "the method was removed" therefore deleted the cached pass of a live
+     * test, and the next run had to execute it again — which recorded a pass,
+     * which got skipped, which got pruned. A suite with zero changes
+     * oscillated between mostly-skipped and mostly-re-run forever.
+     */
+    #[Test]
+    public function prune_stale_results_keeps_a_still_defined_test_that_reported_nothing_this_run(): void
+    {
+        $this->repo->write('tests/GraphTest.php', "<?php\n");
+
+        $graph = $this->graph();
+        $skippedByTia = self::class.'::prune_stale_results_keeps_a_still_defined_test_that_reported_nothing_this_run';
+        $graph->setResult('main', $skippedByTia, 0, '', 0.0, 3, file: 'tests/GraphTest.php');
+
+        // Only a sibling reported this run; the ID above is still a real
+        // method on a real class, so its result must survive.
+        $graph->pruneStaleResults('main', ['tests/GraphTest.php'], [self::class.'::a_sibling_that_ran']);
+
+        $this->assertNotNull($graph->getResult('main', $skippedByTia));
+        $this->assertSame(3, $graph->getAssertions('main', $skippedByTia));
+    }
+
+    /**
+     * Same guarantee for data-provided tests, whose IDs carry a
+     * `#<dataSetName>` suffix that is not part of the method name.
+     */
+    #[Test]
+    public function prune_stale_results_keeps_a_still_defined_data_provided_test(): void
+    {
+        $this->repo->write('tests/GraphTest.php', "<?php\n");
+
+        $graph = $this->graph();
+        $id = self::class.'::prune_stale_results_keeps_a_still_defined_data_provided_test#Spanish';
+        $graph->setResult('main', $id, 0, '', 0.0, 1, file: 'tests/GraphTest.php');
+
+        $graph->pruneStaleResults('main', ['tests/GraphTest.php'], [self::class.'::a_sibling_that_ran']);
+
+        $this->assertNotNull($graph->getResult('main', $id));
+    }
+
+    /**
+     * The original intent still holds: a method that really is gone from a
+     * class that still exists must be dropped.
+     */
+    #[Test]
+    public function prune_stale_results_drops_a_removed_method_of_an_existing_class(): void
+    {
+        $this->repo->write('tests/GraphTest.php', "<?php\n");
+
+        $graph = $this->graph();
+        $id = self::class.'::a_method_that_was_renamed_away';
+        $graph->setResult('main', $id, 0, '', 0.0, file: 'tests/GraphTest.php');
+
+        $graph->pruneStaleResults('main', ['tests/GraphTest.php'], [self::class.'::a_sibling_that_ran']);
+
+        $this->assertNull($graph->getResult('main', $id));
+    }
+
+    /**
+     * A malformed ID carries no class to verify against, so it is treated as
+     * gone rather than kept forever.
+     */
+    #[Test]
+    public function prune_stale_results_drops_an_unparseable_test_id(): void
+    {
+        $this->repo->write('tests/GraphTest.php', "<?php\n");
+
+        $graph = $this->graph();
+        $graph->setResult('main', 'not-a-test-id', 0, '', 0.0, file: 'tests/GraphTest.php');
+
+        $graph->pruneStaleResults('main', ['tests/GraphTest.php'], [self::class.'::a_sibling_that_ran']);
+
+        $this->assertNull($graph->getResult('main', 'not-a-test-id'));
+    }
+
     #[Test]
     public function encode_and_decode_round_trip(): void
     {

--- a/tests/WriteGraphTest.php
+++ b/tests/WriteGraphTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Tests;
+
+use JMac\Testing\PhpUnit\Tia\ChangedFiles;
+use JMac\Testing\PhpUnit\Tia\FileState;
+use JMac\Testing\PhpUnit\Tia\Fingerprint;
+use JMac\Testing\PhpUnit\Tia\Graph;
+use JMac\Testing\PhpUnit\Tia\ResultCollector;
+use JMac\Testing\PhpUnit\Tia\Storage;
+use JMac\Testing\PhpUnit\Tia\Subscribers\WriteGraph;
+use JMac\Testing\PhpUnit\Tia\Tests\Support\TempGitRepository;
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestStatus\TestStatus;
+use ReflectionClass;
+
+/**
+ * Covers the write side end to end: load the on-disk graph, fold in this
+ * run's results, prune, persist.
+ *
+ * The interesting case is a *partial* run, which is what TIA produces by
+ * design — either because it skipped the unaffected tests itself or because
+ * the developer passed `--filter`. Under a partial run the baseline must keep
+ * the results of tests that did not report, or the next run has nothing to
+ * replay and TIA undoes its own work.
+ */
+final class WriteGraphTest extends TestCase
+{
+    private TempGitRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repo = TempGitRepository::create();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->skippedByTia()) {
+            return;
+        }
+
+        if (isset($this->repo)) {
+            $this->repo->cleanup();
+        }
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_keeps_the_baseline_result_of_a_test_that_did_not_report_this_run(): void
+    {
+        $reported = self::class.'::it_keeps_the_baseline_result_of_a_test_that_did_not_report_this_run';
+        $silent = self::class.'::it_persists_a_fresh_result_and_stamps_the_baseline';
+
+        $this->seedBaselineWith([$reported, $silent]);
+
+        // Only `$reported` produced a result — `$silent` is the test TIA
+        // skipped (or `--filter` excluded), so it never reaches
+        // ResultCollector even though its file counts as executed.
+        $results = new ResultCollector;
+        $results->testPrepared($reported, $this->repo->path().'/tests/FooTest.php');
+        $results->testPassed();
+
+        $this->notify($results);
+
+        $graph = $this->persistedGraph();
+
+        $this->assertNotNull($graph->getResult('main', $reported));
+        $this->assertNotNull(
+            $graph->getResult('main', $silent),
+            'A test that reported nothing this run must keep its cached pass — otherwise TIA re-runs it next time.',
+        );
+    }
+
+    #[Test]
+    public function it_persists_a_fresh_result_and_stamps_the_baseline(): void
+    {
+        $testId = self::class.'::it_persists_a_fresh_result_and_stamps_the_baseline';
+
+        $this->seedBaselineWith([]);
+
+        $results = new ResultCollector;
+        $results->testPrepared($testId, $this->repo->path().'/tests/FooTest.php');
+        $results->testPassed();
+        $results->recordAssertions($testId, 4);
+
+        $this->notify($results);
+
+        $graph = $this->persistedGraph();
+        $status = $graph->getResult('main', $testId);
+
+        $this->assertNotNull($status);
+        $this->assertTrue($status->isSuccess());
+        $this->assertSame(4, $graph->getAssertions('main', $testId));
+        $this->assertNotNull($graph->recordedAtSha('main'));
+    }
+
+    /**
+     * The original pruning intent, at this level: a baseline entry whose
+     * method really is gone must not survive a run that executed its file.
+     */
+    #[Test]
+    public function it_drops_the_baseline_result_of_a_test_that_no_longer_exists(): void
+    {
+        $reported = self::class.'::it_drops_the_baseline_result_of_a_test_that_no_longer_exists';
+        $removed = self::class.'::a_method_deleted_in_a_previous_refactor';
+
+        $this->seedBaselineWith([$reported, $removed]);
+
+        $results = new ResultCollector;
+        $results->testPrepared($reported, $this->repo->path().'/tests/FooTest.php');
+        $results->testPassed();
+
+        $this->notify($results);
+
+        $graph = $this->persistedGraph();
+
+        $this->assertNotNull($graph->getResult('main', $reported));
+        $this->assertNull($graph->getResult('main', $removed));
+    }
+
+    #[Test]
+    public function it_rebuilds_from_this_run_alone_when_fresh_is_requested(): void
+    {
+        $stale = self::class.'::a_result_from_a_previous_run';
+        $this->seedBaselineWith([$stale]);
+
+        putenv('PHPUNIT_TIA_FRESH=1');
+
+        try {
+            $this->notify($this->resultsFor(self::class.'::it_rebuilds_from_this_run_alone_when_fresh_is_requested'));
+        } finally {
+            putenv('PHPUNIT_TIA_FRESH');
+        }
+
+        $this->assertNull($this->persistedGraph()->getResult('main', $stale));
+    }
+
+    #[Test]
+    public function it_starts_a_new_graph_when_nothing_is_stored_yet(): void
+    {
+        $this->repo->write('tests/FooTest.php', "<?php\n");
+        $this->repo->commit('seed without a graph');
+
+        $testId = self::class.'::it_starts_a_new_graph_when_nothing_is_stored_yet';
+
+        $this->notify($this->resultsFor($testId));
+
+        $this->assertNotNull($this->persistedGraph()->getResult('main', $testId));
+    }
+
+    #[Test]
+    public function it_starts_a_new_graph_when_the_stored_one_cannot_be_decoded(): void
+    {
+        $this->repo->write('tests/FooTest.php', "<?php\n");
+        $this->repo->commit('seed');
+        $this->state()->write(Storage::GRAPH_KEY, 'not json at all');
+
+        $testId = self::class.'::it_starts_a_new_graph_when_the_stored_one_cannot_be_decoded';
+
+        $this->notify($this->resultsFor($testId));
+
+        $this->assertNotNull($this->persistedGraph()->getResult('main', $testId));
+    }
+
+    /**
+     * composer.lock / phpunit.xml drift means autoloaded classes may have
+     * moved, so edges and baselines are discarded wholesale.
+     */
+    #[Test]
+    public function it_discards_the_baseline_when_the_structural_fingerprint_drifted(): void
+    {
+        $stale = self::class.'::a_result_recorded_under_a_different_lockfile';
+        $this->seedBaselineWith([$stale], fingerprint: [
+            'structural' => ['schema' => -1],
+            'environmental' => ['php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION],
+        ]);
+
+        $this->notify($this->resultsFor(self::class.'::it_discards_the_baseline_when_the_structural_fingerprint_drifted'));
+
+        $this->assertNull($this->persistedGraph()->getResult('main', $stale));
+    }
+
+    /**
+     * A PHP version change leaves the edges plausible but makes a recorded
+     * pass unsafe to replay, so only the results for that branch are cleared.
+     */
+    #[Test]
+    public function it_clears_only_the_results_when_the_environmental_fingerprint_drifted(): void
+    {
+        $stale = self::class.'::a_result_recorded_under_a_different_php_version';
+
+        $fingerprint = Fingerprint::compute($this->repo->path());
+        $fingerprint['environmental']['php_version'] = '1.0';
+
+        $this->seedBaselineWith([$stale], fingerprint: $fingerprint);
+
+        $this->notify($this->resultsFor(self::class.'::it_clears_only_the_results_when_the_environmental_fingerprint_drifted'));
+
+        $this->assertNull($this->persistedGraph()->getResult('main', $stale));
+    }
+
+    private function resultsFor(string $testId): ResultCollector
+    {
+        $results = new ResultCollector;
+        $results->testPrepared($testId, $this->repo->path().'/tests/FooTest.php');
+        $results->testPassed();
+
+        return $results;
+    }
+
+    /**
+     * @param  array<int, string>  $testIds
+     * @param  array<string, mixed>|null  $fingerprint  Defaults to the repo's real fingerprint.
+     */
+    private function seedBaselineWith(array $testIds, ?array $fingerprint = null): void
+    {
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n}\n");
+        $this->repo->write('tests/FooTest.php', "<?php\n");
+        $this->repo->commit('seed');
+
+        $graph = new Graph($this->repo->path());
+
+        foreach ($testIds as $testId) {
+            $graph->setResult('main', $testId, TestStatus::success()->asInt(), '', 0.01, 1, 'tests/FooTest.php');
+        }
+
+        $graph->setFingerprint($fingerprint ?? Fingerprint::compute($this->repo->path()));
+        $graph->setRecordedAtSha('main', (new ChangedFiles($this->repo->path()))->currentSha());
+
+        $this->state()->write(Storage::GRAPH_KEY, (string) $graph->encode());
+    }
+
+    /**
+     * `WriteGraph::notify()` never reads its `ExecutionFinished` argument — it
+     * only needs the event to satisfy the subscriber signature. Building a
+     * real one would mean assembling PHPUnit's whole telemetry value-object
+     * tree (Snapshot, Duration, MemoryUsage, GarbageCollectorStatus) for a
+     * value that is then discarded, so instantiate it without its constructor
+     * instead.
+     */
+    private function notify(ResultCollector $results): void
+    {
+        $event = (new ReflectionClass(ExecutionFinished::class))->newInstanceWithoutConstructor();
+
+        (new WriteGraph($this->repo->path(), $results, 'local'))->notify($event);
+    }
+
+    private function persistedGraph(): Graph
+    {
+        $raw = $this->state()->read(Storage::GRAPH_KEY);
+
+        $this->assertNotNull($raw, 'WriteGraph should have persisted a graph.');
+
+        $graph = Graph::decode($raw, $this->repo->path());
+
+        $this->assertNotNull($graph, 'The persisted graph should decode.');
+
+        return $graph;
+    }
+
+    private function state(): FileState
+    {
+        return new FileState(Storage::resolve($this->repo->path(), 'local'));
+    }
+}


### PR DESCRIPTION
Hi — thanks for building this. I evaluated it on a 5,768-test Laravel 13 suite and hit a reproducible issue where TIA undoes its own work between runs. Root cause and fix below.

## Symptom

With **zero** changes between runs, the suite oscillated on a deterministic two-cycle:

| run | duration | skipped | `graph.json` |
|-----|----------|---------|--------------|
| A | 0:17 | 5,604 / 5,768 | 928K |
| B | 2:16 | 3,555 / 5,768 | 1.5M |
| C | 0:17 | 5,604 / 5,768 | 928K |

Every other run re-executed ~2,200 tests that nothing had touched. Inspecting the graph showed why: a class with 11 tests, of which TIA had skipped 10 and run 1, had exactly **one** result recorded — the one that actually ran. The other ten were gone, not marked skipped.

## Cause

`WriteGraph::notify()` passes `$keepTestIds` (the IDs that produced a result this run) to `Graph::pruneStaleResults()`, which deleted any baseline entry whose file was executed but whose ID was absent from that list — inferring "the method was removed or renamed".

That inference holds only for a **full** run of the file, and TIA's purpose is to make runs partial:

- **A test skipped by `RunWithTia` reports nothing at all.** PHPUnit emits `Test\Prepared` *after* `setUp()`. In `TestCase::runBare()` the order is `HookMethodInvoker::invokeBeforeTest()` (which runs `setUp()`) → `invokePreCondition()` → `$emitter->testPrepared(...)`. Since `setUp()` is the only hook the trait can skip from — the constraint `docs/decisions.md` already establishes — `markTestSkipped()` unwinds before `Prepared` fires, `RecordTestPrepared` never runs, and `ResultCollector::record()` returns early on its null-`$currentTestId` guard. The file is still "touched", because the siblings TIA did *not* skip ran normally.
- **A `--filter`ed run** reports only the selected methods, while their file likewise counts as touched. So the normal inner development loop is quietly destructive to the graph of whatever file is being worked on.

The result was self-defeating: TIA's evidence for skipping a test is its recorded pass, and its own skip destroyed that evidence. Next run there was no cached success, so the test ran for real and recorded a pass; the run after that skipped it and pruned it again.

A **fully** skipped file prunes nothing (`$touched === []` returns early), which is why the suite oscillated rather than degrading monotonically.

## Fix

`pruneStaleResults()` now confirms absence directly rather than inferring it. `Graph::testIsStillDefined()` splits the ID and checks `class_exists()` + `method_exists()`.

IDs are `Class::method` with an optional `#<dataSetName>` suffix. A class name cannot contain `::` and a method name cannot contain `#`, so the first occurrence of each is the correct split point even when a data-set name contains either character.

An unparseable ID, or one whose class no longer resolves, is still reported as gone — that is the pre-existing behaviour for a deleted test file, and keeping unresolvable entries forever would grow the baseline without bound.

I considered the narrower alternative of having `RunWithTia` register its skipped IDs so they land in `$keepTestIds`. It fixes the skip case but not the `--filter` case, because filtered-out methods are never instantiated and so can never register themselves. Verifying existence addresses the premise instead of the symptom, which is why I went that way — happy to switch if you'd rather keep the change smaller.

## Tests

Both levels, and I verified the three key cases **fail against the previous `Graph.php`** and pass with this change:

```
1) GraphTest::prune_stale_results_keeps_a_still_defined_test_that_reported_nothing_this_run
2) GraphTest::prune_stale_results_keeps_a_still_defined_data_provided_test
3) WriteGraphTest::it_keeps_the_baseline_result_of_a_test_that_did_not_report_this_run
Tests: 8, Failures: 3
```

- **`GraphTest`** — four cases: keeps a live test that reported nothing, keeps a data-provided one, still drops a renamed method of an existing class, still drops an unparseable ID. That covers all four `testIsStillDefined()` branches.
- **`tests/WriteGraphTest.php`** (new) — the write path had no tests at all (0 of 52 lines) and it is where the partial-run condition is produced, so the regression deserved a test at that level too. Also covers every `loadGraph()` branch: fresh, nothing stored, undecodable, structural drift, environmental drift.

`WriteGraph::notify()` never reads its `ExecutionFinished` argument, so the test instantiates it without its constructor rather than assembling PHPUnit's telemetry value-object tree for a value that is discarded. Noted in a comment in case you'd prefer it built for real.

| | before | after |
|---|---|---|
| Suite | 106 tests | **118 tests, 185 assertions, green** |
| `src/Subscribers/WriteGraph.php` | 0% | **98.1%** (51/52) |
| `src/Graph.php` | 79.8% | 82.6% |
| new code in this PR | — | **100%**, all four branches |

The single remaining `WriteGraph` line is the `$coverage->isActive()` true branch of `Recorder::invert(...)`, which depends on the runner-owned `PHPUnit\Runner\CodeCoverage` singleton being active. I left it rather than manipulate a runner-owned global from a unit test.

`src/Graph.php` sits at 82.6% because of pre-existing gaps in methods this PR does not touch. I have a follow-up branch that closes those; keeping it separate so this PR stays reviewable as a behaviour fix rather than a coverage sweep.

## Docs

`docs/decisions.md` gains a section in the existing style — *"Why staleness is verified by reflection, not inferred from 'did not report'"* — with the exact `runBare()` ordering that causes it, the measurements above, why a fully-skipped file prunes nothing, and a note that this also explains a misleading symptom: a partial run followed by a second runner (paratest, for instance) leaves that runner almost nothing to replay, which reads as "TIA doesn't work with my runner" rather than as a pruning bug. I chased that false lead myself before finding this.

Pint passes. 4 files, +207/-1.
