### PR TITLE
Fix zero source-to-test edges under php-code-coverage >= 14.3

### DIFF
--- a/src/Recorder.php
+++ b/src/Recorder.php
@@ -23,21 +23,34 @@ namespace JMac\Testing\PhpUnit\Tia;
 final class Recorder
 {
     /**
-     * @param  array<string, array<int, list<string>|null>>  $lineCoverage
+     * @param  array<string, array<int, array<int, int>|list<string>|null>>  $lineCoverage
      * @param  array<string, array{status: int, message: string, time: float, assertions: int, file?: string}>  $results
+     * @param  array<int, string>  $testIdByIndex  php-code-coverage >= 14.3 keys each covered line's
+     *         hit map by an integer TestIndex (`<TestIndex => hitFlag>`); this translates that index
+     *         back to the test id string. Pass the empty default for the legacy
+     *         `<line => list<testIdString>>` shape, where the id is the value itself.
      * @return array<string, list<string>> test file (absolute) → list of source files (absolute)
      */
-    public static function invert(array $lineCoverage, array $results): array
+    public static function invert(array $lineCoverage, array $results, array $testIdByIndex = []): array
     {
         $edges = [];
 
         foreach ($lineCoverage as $sourceFile => $lines) {
-            foreach ($lines as $testIds) {
-                if ($testIds === null) {
+            foreach ($lines as $perLine) {
+                if ($perLine === null) {
                     continue;
                 }
 
-                foreach ($testIds as $testId) {
+                foreach ($perLine as $key => $value) {
+                    // Legacy php-code-coverage: `<line => list<testIdString>>` — the id is the value.
+                    // php-code-coverage >= 14.3: `<line => <TestIndex => hitFlag>>` — the id is keyed
+                    // by index, and the value is a hit flag, so translate the key via $testIdByIndex.
+                    $testId = is_string($value) ? $value : ($testIdByIndex[$key] ?? null);
+
+                    if ($testId === null) {
+                        continue;
+                    }
+
                     $testFile = $results[$testId]['file'] ?? null;
 
                     if ($testFile === null) {

--- a/src/Recorder.php
+++ b/src/Recorder.php
@@ -26,9 +26,9 @@ final class Recorder
      * @param  array<string, array<int, array<int, int>|list<string>|null>>  $lineCoverage
      * @param  array<string, array{status: int, message: string, time: float, assertions: int, file?: string}>  $results
      * @param  array<int, string>  $testIdByIndex  php-code-coverage >= 14.3 keys each covered line's
-     *         hit map by an integer TestIndex (`<TestIndex => hitFlag>`); this translates that index
-     *         back to the test id string. Pass the empty default for the legacy
-     *         `<line => list<testIdString>>` shape, where the id is the value itself.
+     *                                             hit map by an integer TestIndex (`<TestIndex => hitFlag>`); this translates that index
+     *                                             back to the test id string. Pass the empty default for the legacy
+     *                                             `<line => list<testIdString>>` shape, where the id is the value itself.
      * @return array<string, list<string>> test file (absolute) → list of source files (absolute)
      */
     public static function invert(array $lineCoverage, array $results, array $testIdByIndex = []): array

--- a/src/Subscribers/WriteGraph.php
+++ b/src/Subscribers/WriteGraph.php
@@ -46,9 +46,13 @@ final readonly class WriteGraph implements ExecutionFinishedSubscriber
         $results = $this->results->all();
 
         $coverage = CodeCoverage::instance();
-        $edges = $coverage->isActive()
-            ? Recorder::invert($coverage->codeCoverage()->getData()->lineCoverage(), $results)
-            : [];
+        $edges = [];
+
+        if ($coverage->isActive()) {
+            $data = $coverage->codeCoverage()->getData();
+            $edges = Recorder::invert($data->lineCoverage(), $results, $data->testIds());
+        }
+
         $graph->replaceEdges($edges);
 
         $executedTestFiles = [];

--- a/tests/RecorderTest.php
+++ b/tests/RecorderTest.php
@@ -94,4 +94,46 @@ final class RecorderTest extends TestCase
         $this->assertSame(['/app/src/Calculator.php'], $edges['/app/tests/CalculatorTest.php']);
         $this->assertSame(['/app/src/Calculator.php'], $edges['/app/tests/SubtractionTest.php']);
     }
+
+    #[Test]
+    public function it_inverts_index_keyed_line_coverage_from_php_code_coverage_14_3(): void
+    {
+        // php-code-coverage >= 14.3 interns test ids: each covered line maps
+        // <TestIndex => hitFlag> instead of a list of test-id strings, and the
+        // index resolves to a test id via ProcessedCodeCoverageData::testIds().
+        $lineCoverage = [
+            '/app/src/Calculator.php' => [
+                11 => [0 => 1],
+                16 => [1 => 1],
+            ],
+        ];
+
+        $testIdByIndex = [
+            0 => 'Tests\\CalculatorTest::test_it_adds',
+            1 => 'Tests\\CalculatorTest::test_it_subtracts',
+        ];
+
+        $results = [
+            'Tests\\CalculatorTest::test_it_adds' => ['status' => 0, 'message' => '', 'time' => 0.0, 'assertions' => 1, 'file' => '/app/tests/CalculatorTest.php'],
+            'Tests\\CalculatorTest::test_it_subtracts' => ['status' => 0, 'message' => '', 'time' => 0.0, 'assertions' => 1, 'file' => '/app/tests/CalculatorTest.php'],
+        ];
+
+        $edges = Recorder::invert($lineCoverage, $results, $testIdByIndex);
+
+        $this->assertSame(['/app/tests/CalculatorTest.php' => ['/app/src/Calculator.php']], $edges);
+    }
+
+    #[Test]
+    public function it_skips_an_index_keyed_hit_with_no_known_test_index(): void
+    {
+        // The hit flag value (1) must never be mistaken for a test id, and an
+        // index absent from the map is skipped rather than producing a false edge.
+        $lineCoverage = [
+            '/app/src/Calculator.php' => [
+                11 => [7 => 1],
+            ],
+        ];
+
+        $this->assertSame([], Recorder::invert($lineCoverage, [], []));
+    }
 }


### PR DESCRIPTION
## Summary

Under **php-code-coverage >= 14.3**, `Recorder::invert()` records **zero source-to-test edges**, so Test Impact Analysis silently stops detecting source changes — only a change to a test's *own* file still triggers a re-run. A production-code change is replayed as "unaffected, last run passed" (a false green), which is worse than no speedup on a critical suite.

## Root cause

php-code-coverage 14.3 interns test ids. `ProcessedCodeCoverageData::lineCoverage()` is now typed (`@phpstan-type LineCoverageType`):

```
array<non-empty-string, array<positive-int, null|array<TestIndexType, positive-int>>>
```

Per covered line, the **keys** are now `TestIndex` integers and the **values** are hit flags — previously each line held a `list<testIdString>`. `Recorder::invert()` iterated the values and treated them as test ids, so `$results[$hitFlag]` never matched a real id (`Tests\Foo::bar`) and every edge was dropped.

The index-to-id map is available as `ProcessedCodeCoverageData::testIds()` (`array<TestIndexType, TestIdType>`), but `invert()` was never given it.

## Fix

- `Recorder::invert()` takes an optional `array $testIdByIndex = []`. Per covered line it now iterates `$key => $value` and resolves the test id as `is_string($value) ? $value : ($testIdByIndex[$key] ?? null)` — so the legacy `list<testId>` shape and the new index-keyed shape both work. Backward compatible with older php-code-coverage.
- `Subscribers\WriteGraph::notify()` passes `$data->testIds()` alongside `$data->lineCoverage()`.

## Tests

- Existing `RecorderTest` cases (legacy list shape) unchanged and passing.
- Added a case for the 14.3 index-keyed shape resolving through `testIdByIndex`, and one asserting an index absent from the map is skipped (never mistaking a hit flag for an id).
- Full suite green on PHP 8.5 with php-code-coverage 14.3.0: `OK (108 tests, 153 assertions)`.

## Real-world impact observed

Adopting TIA across a multi-service PHP monorepo, every service recorded an edgeless graph (e.g. 120 known test files, 0 source links). After this fix, re-recording produced correct edges (37/41 test files linked, 56 source files), and a source-only change re-ran exactly its covering tests instead of being skipped.
