### PR TITLE
Run only the impacted test files, instead of constructing and skipping the rest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,21 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
 
+      - name: Cache fixture-app dependencies
+        uses: actions/cache@v6
+        with:
+          path: tests/fixture-app/vendor
+          key: composer-fixture-${{ runner.os }}-${{ hashFiles('tests/fixture-app/composer.json') }}
+          restore-keys: |
+            composer-fixture-${{ runner.os }}-
+
+      - name: Install fixture-app dependencies
+        # The wrapper binary's end-to-end tests drive tests/fixture-app as a
+        # real consumer project via a subprocess. Without its own vendor/ they
+        # skip, so CI would report green while covering none of that path.
+        working-directory: tests/fixture-app
+        run: composer install --prefer-dist --no-interaction --no-progress
+
       - name: Cache phpunit-tia graph
         uses: actions/cache@v6
         with:

--- a/README.md
+++ b/README.md
@@ -82,13 +82,27 @@ The trait skips inside `setUp()`, so an unaffected test is still constructed bef
 vendor/bin/phpunit-tia
 ```
 
-It works out which test files are impacted, then re-execs the real `phpunit` with only those files, so unaffected tests are never constructed at all. Every argument you pass is handed through untouched:
+It works out which test files are impacted, then re-execs the real `phpunit` with only those files, so unaffected tests are never constructed at all.
+
+Every option you pass is handed through to `phpunit` untouched, and applies *within* the impacted set:
 
 ```sh
-vendor/bin/phpunit-tia --stop-on-failure tests/Feature
+vendor/bin/phpunit-tia --stop-on-failure
+vendor/bin/phpunit-tia --filter it_creates_a_widget
+vendor/bin/phpunit-tia --testdox --do-not-cache-result
 ```
 
-A path you supply narrows the selection rather than replacing it — the example above runs the impacted tests *within* `tests/Feature`.
+A path narrows the selection rather than replacing it, so this runs the impacted tests *within* `tests/Feature`:
+
+```sh
+vendor/bin/phpunit-tia tests/Feature
+```
+
+Both combine, and each only ever shrinks what runs:
+
+```sh
+vendor/bin/phpunit-tia --filter Widget tests/Feature
+```
 
 The binary is a complement to the trait, not a replacement: keep the trait installed so the graph stays warm, and keep the extension registered so runs keep recording.
 
@@ -97,7 +111,10 @@ The binary is a complement to the trait, not a replacement: keep the trait insta
 - The first run has nothing to work from, so it runs the full suite. It needs `pcov` or `xdebug`, otherwise nothing is ever recorded and every later run stays full.
 - When nothing is impacted, it runs nothing and exits `0`.
 - Anything uncertain — no baseline, a fingerprint change, an unreachable baseline commit, a test file the graph has never seen — falls back to running the full suite. It will never run *fewer* tests than it can justify.
-- `PHPUNIT_TIA=0` and `PHPUNIT_TIA_FRESH=1` bypass it exactly as they bypass the trait.
+- `PHPUNIT_TIA=0` and `PHPUNIT_TIA_FRESH=1` bypass it exactly as they bypass the trait, running the full suite with your arguments untouched.
+- `PHPUNIT_TIA_BINARY` points at the `phpunit` to re-exec, for projects whose Composer `bin-dir` is not `vendor/bin`. It defaults to `vendor/bin/phpunit`.
+
+Note that impact is judged behaviourally, so editing only comments or whitespace in a source file will correctly select nothing.
 
 ## CI Workflows
 To use TIA in CI, your baseline graph must persist between runs. See our own [GitHub Action workflow](.github/workflows/tests.yml) for an example. At a high level, your workflow needs to:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ PHPUNIT_TIA_FRESH=1 phpunit ...
 
 **Note:** running tests with the `--fail-on-skipped` or `--display-skipped` option will automatically bypass TIA's speed boost. You will need to drop these options to take full advantage of TIA.
 
+## Selecting instead of skipping
+The trait skips inside `setUp()`, so an unaffected test is still constructed before it is skipped. To avoid that cost entirely, run the suite through the wrapper binary:
+
+```sh
+vendor/bin/phpunit-tia
+```
+
+It works out which test files are impacted, then re-execs the real `phpunit` with only those files, so unaffected tests are never constructed at all. Every argument you pass is handed through untouched:
+
+```sh
+vendor/bin/phpunit-tia --stop-on-failure tests/Feature
+```
+
+A path you supply narrows the selection rather than replacing it — the example above runs the impacted tests *within* `tests/Feature`.
+
+The binary is a complement to the trait, not a replacement: keep the trait installed so the graph stays warm, and keep the extension registered so runs keep recording.
+
+**Requirements and behaviour:**
+
+- The first run has nothing to work from, so it runs the full suite. It needs `pcov` or `xdebug`, otherwise nothing is ever recorded and every later run stays full.
+- When nothing is impacted, it runs nothing and exits `0`.
+- Anything uncertain — no baseline, a fingerprint change, an unreachable baseline commit, a test file the graph has never seen — falls back to running the full suite. It will never run *fewer* tests than it can justify.
+- `PHPUNIT_TIA=0` and `PHPUNIT_TIA_FRESH=1` bypass it exactly as they bypass the trait.
+
 ## CI Workflows
 To use TIA in CI, your baseline graph must persist between runs. See our own [GitHub Action workflow](.github/workflows/tests.yml) for an example. At a high level, your workflow needs to:
 

--- a/bin/phpunit-tia
+++ b/bin/phpunit-tia
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use JMac\Testing\PhpUnit\Tia\Cli\Command;
+
+foreach ([__DIR__.'/../../../autoload.php', __DIR__.'/../vendor/autoload.php'] as $autoload) {
+    if (is_file($autoload)) {
+        require $autoload;
+
+        break;
+    }
+}
+
+if (! class_exists(Command::class)) {
+    fwrite(STDERR, "phpunit-tia: could not locate the composer autoloader.\n");
+
+    exit(1);
+}
+
+$arguments = $argv;
+array_shift($arguments);
+
+exit((new Command(getcwd(), array_values($arguments)))->run());

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
     "conflict": {
         "phpunit/phpunit": "<13.2.6"
     },
+    "bin": [
+        "bin/phpunit-tia"
+    ],
     "autoload": {
         "psr-4": {
             "JMac\\Testing\\PhpUnit\\Tia\\": "src/"

--- a/src/Cli/Arguments.php
+++ b/src/Cli/Arguments.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Cli;
+
+use PHPUnit\TextUI\CliArguments\Builder as CliBuilder;
+
+/**
+ * Splits a phpunit argv into the positional test paths the user asked for and
+ * the options to hand straight through to the real runner.
+ *
+ * PHPUnit's own CLI parser does the hard part: it knows which options take a
+ * value, so `--filter tests/FooTest.php` is not mistaken for a path.
+ */
+final readonly class Arguments
+{
+    /**
+     * @param  list<string>  $argv
+     * @param  list<string>  $paths
+     */
+    private function __construct(private array $argv, private array $paths) {}
+
+    /**
+     * @param  list<string>  $argv  phpunit arguments, without the script name.
+     */
+    public static function fromArgv(array $argv): self
+    {
+        return new self($argv, (new CliBuilder)->fromParameters($argv)->arguments());
+    }
+
+    /** @return list<string> */
+    public function paths(): array
+    {
+        return $this->paths;
+    }
+
+    /**
+     * The original argv with the positional paths removed, ready to be
+     * combined with a computed selection.
+     *
+     * The parser reports path values, not their positions, so removal is by
+     * value — but only as many occurrences as it reported, scanning from the
+     * end. That keeps an option value spelled like a path (`--filter
+     * tests/FooTest.php`) intact, since positional paths conventionally come
+     * last.
+     *
+     * @return list<string>
+     */
+    public function passthrough(): array
+    {
+        $removable = array_count_values($this->paths);
+        $argv = $this->argv;
+
+        for ($i = count($argv) - 1; $i >= 0; $i--) {
+            $token = $argv[$i];
+
+            if (($removable[$token] ?? 0) > 0) {
+                $removable[$token]--;
+
+                unset($argv[$i]);
+            }
+        }
+
+        return array_values($argv);
+    }
+}

--- a/src/Cli/Command.php
+++ b/src/Cli/Command.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Cli;
+
+use JMac\Testing\PhpUnit\Tia\Config;
+use JMac\Testing\PhpUnit\Tia\Extension;
+use JMac\Testing\PhpUnit\Tia\Tia;
+use PHPUnit\TextUI\CliArguments\Builder as CliBuilder;
+use PHPUnit\TextUI\Configuration\Registry;
+use PHPUnit\TextUI\XmlConfiguration\Loader;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+/**
+ * Computes the affected set before PHPUnit boots, then re-execs the real
+ * runner with only the test files that need to run.
+ *
+ * The trait can only skip inside setUp(), so an unaffected TestCase is still
+ * constructed. Selecting up front means it never is.
+ */
+final readonly class Command
+{
+    private const CONFIGURATION_CANDIDATES = ['phpunit.xml', 'phpunit.xml.dist'];
+
+    /**
+     * @param  list<string>  $argv  phpunit arguments, without the script name.
+     */
+    public function __construct(
+        private string $projectRoot,
+        private array $argv,
+    ) {}
+
+    public function run(): int
+    {
+        $arguments = Arguments::fromArgv($this->argv);
+        $plan = $this->plan($arguments);
+
+        $this->report($plan);
+
+        if ($plan->isRunNothing()) {
+            return 0;
+        }
+
+        return $this->execute($plan->isRunAll() ? $this->argv : [...$plan->paths(), ...$arguments->passthrough()]);
+    }
+
+    /**
+     * Any uncertainty resolves to running everything. A wrapper bug should
+     * cost time, never a missed regression.
+     */
+    private function plan(Arguments $arguments): Plan
+    {
+        if (! Tia::isEnabled()) {
+            return Plan::runAll('disabled via PHPUNIT_TIA=0');
+        }
+
+        if (Tia::isFresh()) {
+            return Plan::runAll('rebuilding the baseline via PHPUNIT_TIA_FRESH=1');
+        }
+
+        $configurationFile = $this->configurationFile();
+
+        if ($configurationFile === null) {
+            return Plan::runAll('no phpunit configuration found');
+        }
+
+        try {
+            Registry::init(
+                (new CliBuilder)->fromParameters($arguments->passthrough()),
+                (new Loader)->load($configurationFile),
+            );
+
+            Tia::configure($this->projectRoot, $this->storageMode(), Config::loadResolvers($this->projectRoot));
+
+            return (new Selection(Tia::instance()))->plan(
+                SuiteFiles::fromProjectRoot($this->projectRoot)->all(),
+                $arguments->paths(),
+            );
+        } catch (Throwable $e) {
+            return Plan::runAll('could not plan the run: '.$e->getMessage());
+        }
+    }
+
+    private function configurationFile(): ?string
+    {
+        foreach (self::CONFIGURATION_CANDIDATES as $candidate) {
+            $path = $this->projectRoot.'/'.$candidate;
+
+            if (is_file($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Read from the same place the extension reads it, or the two resolve
+     * different storage directories and the binary silently finds no graph.
+     */
+    private function storageMode(): string
+    {
+        foreach (Registry::get()->extensionBootstrappers() as $bootstrap) {
+            if (($bootstrap['className'] ?? null) === Extension::class) {
+                return $bootstrap['parameters']['storage'] ?? 'global';
+            }
+        }
+
+        return 'global';
+    }
+
+    private function report(Plan $plan): void
+    {
+        fwrite(STDERR, 'phpunit-tia: '.$plan->reason().".\n");
+    }
+
+    /**
+     * @param  list<string>  $arguments
+     */
+    private function execute(array $arguments): int
+    {
+        $binary = $this->phpunitBinary();
+
+        if ($binary === null) {
+            fwrite(STDERR, "phpunit-tia: could not find the phpunit binary.\n");
+
+            return 1;
+        }
+
+        $process = new Process([PHP_BINARY, $binary, ...$arguments], $this->projectRoot, timeout: null);
+
+        if (Process::isTtySupported()) {
+            $process->setTty(true);
+        }
+
+        return $process->run(function (string $type, string $buffer): void {
+            fwrite($type === Process::ERR ? STDERR : STDOUT, $buffer);
+        });
+    }
+
+    private function phpunitBinary(): ?string
+    {
+        $configured = getenv('PHPUNIT_TIA_BINARY');
+
+        if (is_string($configured) && $configured !== '' && is_file($configured)) {
+            return $configured;
+        }
+
+        $default = $this->projectRoot.'/vendor/bin/phpunit';
+
+        return is_file($default) ? $default : null;
+    }
+}

--- a/src/Cli/Outcome.php
+++ b/src/Cli/Outcome.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Cli;
+
+/**
+ * The three things the wrapper can decide. See Plan for why "nothing" and
+ * "all" are separate cases rather than one empty list.
+ */
+enum Outcome
+{
+    case All;
+    case Nothing;
+    case Paths;
+}

--- a/src/Cli/Plan.php
+++ b/src/Cli/Plan.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Cli;
+
+/**
+ * What the wrapper decided to do, and why.
+ *
+ * The two empty outcomes are deliberately distinct types rather than an empty
+ * list: "nothing to run" exits clean, while "cannot narrow safely" runs the
+ * whole suite. Handing PHPUnit an empty path list would run everything, so
+ * collapsing them would turn a no-op into a full run — or worse, a full run
+ * into a silent no-op.
+ */
+final readonly class Plan
+{
+    /**
+     * @param  list<string>  $paths
+     */
+    private function __construct(
+        private Outcome $outcome,
+        private array $paths,
+        private string $reason,
+    ) {}
+
+    public static function runAll(string $reason): self
+    {
+        return new self(Outcome::All, [], $reason);
+    }
+
+    public static function runNothing(string $reason): self
+    {
+        return new self(Outcome::Nothing, [], $reason);
+    }
+
+    /**
+     * @param  list<string>  $paths
+     */
+    public static function runPaths(array $paths, string $reason): self
+    {
+        return new self(Outcome::Paths, $paths, $reason);
+    }
+
+    public function isRunAll(): bool
+    {
+        return $this->outcome === Outcome::All;
+    }
+
+    public function isRunNothing(): bool
+    {
+        return $this->outcome === Outcome::Nothing;
+    }
+
+    /** @return list<string> */
+    public function paths(): array
+    {
+        return $this->paths;
+    }
+
+    public function reason(): string
+    {
+        return $this->reason;
+    }
+}

--- a/src/Cli/Selection.php
+++ b/src/Cli/Selection.php
@@ -33,6 +33,7 @@ final readonly class Selection
         $candidates = array_unique(array_merge(
             $this->tia->affectedTestFiles(),
             $this->tia->testFilesToRerun(),
+            $this->tia->testFilesWithoutCachedSuccess(),
             array_values(array_diff($suiteFiles, $this->tia->knownTestFiles())),
         ));
 

--- a/src/Cli/Selection.php
+++ b/src/Cli/Selection.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Cli;
+
+use JMac\Testing\PhpUnit\Tia\Tia;
+
+/**
+ * Turns the impact analysis into a Plan.
+ *
+ * Every uncertainty resolves to running more tests, never fewer: a wrapper bug
+ * should cost time, not a missed regression.
+ */
+final readonly class Selection
+{
+    public function __construct(private Tia $tia) {}
+
+    /**
+     * @param  list<string>  $suiteFiles  Project-relative test files the configured suite would run.
+     * @param  list<string>  $userPaths  Paths the user asked for, if any.
+     */
+    public function plan(array $suiteFiles, array $userPaths): Plan
+    {
+        if (! $this->tia->isActive()) {
+            return Plan::runAll('no usable baseline graph');
+        }
+
+        if ($this->tia->hasUnlocatedTestsToRerun()) {
+            return Plan::runAll('a test that must re-run has no resolvable file');
+        }
+
+        $candidates = array_unique(array_merge(
+            $this->tia->affectedTestFiles(),
+            $this->tia->testFilesToRerun(),
+            array_values(array_diff($suiteFiles, $this->tia->knownTestFiles())),
+        ));
+
+        // The suite is the authority on what may run at all: positional paths
+        // bypass <exclude>, so emitting a file it would not run can execute
+        // something the project deliberately keeps out, and fatal.
+        $selected = array_values(array_intersect($candidates, $suiteFiles));
+
+        if ($userPaths !== []) {
+            $selected = array_values(array_filter(
+                $selected,
+                fn (string $file): bool => self::isUnder($file, $userPaths),
+            ));
+        }
+
+        if ($selected === []) {
+            return Plan::runNothing('nothing affected');
+        }
+
+        return Plan::runPaths($selected, sprintf(
+            '%d of %d test files selected',
+            count($selected),
+            count($suiteFiles),
+        ));
+    }
+
+    /**
+     * A user-supplied argument narrows the selection rather than adding to it,
+     * so `phpunit-tia tests/Feature` means "affected within tests/Feature".
+     *
+     * @param  list<string>  $paths
+     */
+    private static function isUnder(string $file, array $paths): bool
+    {
+        foreach ($paths as $path) {
+            $path = rtrim($path, '/');
+
+            if ($file === $path || str_starts_with($file, $path.'/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Cli/SuiteFiles.php
+++ b/src/Cli/SuiteFiles.php
@@ -27,9 +27,24 @@ final readonly class SuiteFiles
 
     public static function fromProjectRoot(string $projectRoot): self
     {
+        $configuration = Registry::get();
+        $include = $configuration->includeTestSuites();
+        $excludedSuites = $configuration->excludeTestSuites();
+
         $files = [];
 
-        foreach (Registry::get()->testSuite() as $suite) {
+        foreach ($configuration->testSuite() as $suite) {
+            // --testsuite / --exclude-testsuite restrict the run to named
+            // suites. Ignoring them would select files the user excluded, and
+            // pull in every never-recorded file from those suites.
+            if ($include !== [] && ! in_array($suite->name(), $include, true)) {
+                continue;
+            }
+
+            if (in_array($suite->name(), $excludedSuites, true)) {
+                continue;
+            }
+
             $exclude = [];
 
             foreach ($suite->exclude() as $excluded) {

--- a/src/Cli/SuiteFiles.php
+++ b/src/Cli/SuiteFiles.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Cli;
+
+use PHPUnit\TextUI\Configuration\Registry;
+use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
+
+/**
+ * The set of test files the configured suite would actually run, as
+ * project-relative paths.
+ *
+ * This is the authority the selection is intersected with. Positional paths
+ * bypass <testsuite><exclude> — handing PHPUnit an excluded file runs it, and
+ * can fatal — so a candidate that is not in this list must never be emitted.
+ *
+ * It reads the same source PHPUnit's own TestSuiteMapper does, and applies the
+ * exclusions with the same call, so the two cannot drift apart.
+ */
+final readonly class SuiteFiles
+{
+    /**
+     * @param  list<string>  $files  Project-relative test file paths.
+     */
+    private function __construct(private array $files) {}
+
+    public static function fromProjectRoot(string $projectRoot): self
+    {
+        $files = [];
+
+        foreach (Registry::get()->testSuite() as $suite) {
+            $exclude = [];
+
+            foreach ($suite->exclude() as $excluded) {
+                $exclude[] = $excluded->path();
+            }
+
+            foreach ($suite->directories() as $directory) {
+                $found = (new FileIteratorFacade)->getFilesAsArray(
+                    $directory->path(),
+                    $directory->suffix(),
+                    $directory->prefix(),
+                    $exclude,
+                );
+
+                foreach ($found as $file) {
+                    $files[] = $file;
+                }
+            }
+
+            foreach ($suite->files() as $file) {
+                $files[] = $file->path();
+            }
+        }
+
+        return new self(self::toRelative($files, $projectRoot));
+    }
+
+    /** @return list<string> */
+    public function all(): array
+    {
+        return $this->files;
+    }
+
+    public function contains(string $relativePath): bool
+    {
+        return in_array($relativePath, $this->files, true);
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @return list<string>
+     */
+    private static function toRelative(array $paths, string $projectRoot): array
+    {
+        $root = str_replace(DIRECTORY_SEPARATOR, '/', rtrim($projectRoot, '/\\')).'/';
+        $relative = [];
+
+        foreach ($paths as $path) {
+            $path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
+
+            if (str_starts_with($path, $root)) {
+                $relative[] = substr($path, strlen($root));
+            }
+        }
+
+        return array_values(array_unique($relative));
+    }
+}

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -443,6 +443,44 @@ final class Graph
     /**
      * @return array<int, string>
      */
+    /**
+     * Test files holding any result that is not a success.
+     *
+     * cachedStatusIfUnaffected() replays a cached result only when it is a
+     * success, so anything else is re-executed. A selector working at file
+     * level has to apply the same rule, or a test skipped for a missing
+     * service stays unrun indefinitely: the fingerprint tracks the PHP version
+     * and the composer/phpunit files, so making that service available does
+     * not invalidate the graph.
+     *
+     * @return list<string>
+     */
+    public function testFilesWithoutCachedSuccess(string $branch, string $fallbackBranch = 'main'): array
+    {
+        $baseline = $this->baselineFor($branch, $fallbackBranch);
+        $files = [];
+
+        foreach ($baseline['results'] as $result) {
+            if (TestStatus::from($result['status'])->isSuccess()) {
+                continue;
+            }
+
+            $file = $result['file'] ?? null;
+
+            if (! is_string($file) || $file === '') {
+                continue;
+            }
+
+            $rel = $this->relative($file);
+
+            if ($rel !== null) {
+                $files[$rel] = true;
+            }
+        }
+
+        return array_keys($files);
+    }
+
     public function testFilesToRerun(string $branch, string $fallbackBranch = 'main'): array
     {
         $baseline = $this->baselineFor($branch, $fallbackBranch);

--- a/src/Tia.php
+++ b/src/Tia.php
@@ -86,6 +86,63 @@ final class Tia
     }
 
     /**
+     * Whether the impact analysis actually ran: a graph was decoded, its
+     * fingerprint still matches, and the baseline sha was reachable from HEAD.
+     *
+     * Callers that *select* which tests to run need this to read an empty
+     * affectedTestFiles() correctly — inactive means "could not narrow, run
+     * everything", not "nothing is affected".
+     */
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    /**
+     * The project-relative test files impacted by this run's changes.
+     *
+     * Only meaningful when isActive() is true.
+     *
+     * @return list<string>
+     */
+    public function affectedTestFiles(): array
+    {
+        return array_keys($this->affectedTestFiles);
+    }
+
+    /**
+     * Test files holding a result the policy says must run again — a failure,
+     * or anything --fail-on-* elevates. They sit in unchanged files, so the
+     * affected set alone would miss them.
+     *
+     * @return list<string>
+     */
+    public function testFilesToRerun(): array
+    {
+        return $this->graph?->testFilesToRerun($this->branch) ?? [];
+    }
+
+    /**
+     * Whether some result that must re-run has no file to name it by, which
+     * makes a path-based selection unable to express the run.
+     */
+    public function hasUnlocatedTestsToRerun(): bool
+    {
+        return $this->graph?->hasUnlocatedTestsToRerun($this->branch) ?? false;
+    }
+
+    /**
+     * Every test file the graph has recorded. Its complement against the
+     * configured suite is what has never been seen, and must always run.
+     *
+     * @return list<string>
+     */
+    public function knownTestFiles(): array
+    {
+        return $this->graph?->allTestFiles() ?? [];
+    }
+
+    /**
      * Only ever returns a cached **success** status — §4.7's deliberate
      * simplification vs. Pest's four-way ReplayType. A cached failure/error
      * needs a fresh stack trace, not a stale message, and risky/incomplete

--- a/src/Tia.php
+++ b/src/Tia.php
@@ -123,6 +123,18 @@ final class Tia
     }
 
     /**
+     * Test files whose cached result is anything other than a success, which
+     * the trait re-executes rather than replaying. A file-level selector must
+     * match that rule to avoid pruning a test the trait would have run.
+     *
+     * @return list<string>
+     */
+    public function testFilesWithoutCachedSuccess(): array
+    {
+        return $this->graph?->testFilesWithoutCachedSuccess($this->branch) ?? [];
+    }
+
+    /**
      * Whether some result that must re-run has no file to name it by, which
      * makes a path-based selection unable to express the run.
      */

--- a/tests/Cli/ArgumentsTest.php
+++ b/tests/Cli/ArgumentsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Tests\Cli;
+
+use JMac\Testing\PhpUnit\Tia\Cli\Arguments;
+use JMac\Testing\PhpUnit\Tia\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ArgumentsTest extends TestCase
+{
+    #[Test]
+    public function it_extracts_the_positional_paths(): void
+    {
+        $arguments = Arguments::fromArgv(['--filter', 'Foo', 'tests/AaTest.php', 'tests/BbTest.php', '--stop-on-failure']);
+
+        $this->assertSame(['tests/AaTest.php', 'tests/BbTest.php'], $arguments->paths());
+    }
+
+    #[Test]
+    public function it_hands_the_remaining_options_through_untouched(): void
+    {
+        $arguments = Arguments::fromArgv(['--filter', 'Foo', 'tests/AaTest.php', 'tests/BbTest.php', '--stop-on-failure']);
+
+        $this->assertSame(['--filter', 'Foo', '--stop-on-failure'], $arguments->passthrough());
+    }
+
+    /**
+     * An option value can be spelled exactly like a positional path. Only the
+     * positional occurrence may be removed — stripping the value too would
+     * silently change the filter the user asked for.
+     */
+    #[Test]
+    public function it_keeps_an_option_value_spelled_like_a_positional_path(): void
+    {
+        $arguments = Arguments::fromArgv(['--filter', 'tests/AaTest.php', 'tests/AaTest.php']);
+
+        $this->assertSame(['tests/AaTest.php'], $arguments->paths());
+        $this->assertSame(['--filter', 'tests/AaTest.php'], $arguments->passthrough());
+    }
+}

--- a/tests/Cli/PlanTest.php
+++ b/tests/Cli/PlanTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Tests\Cli;
+
+use JMac\Testing\PhpUnit\Tia\Cli\Plan;
+use JMac\Testing\PhpUnit\Tia\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class PlanTest extends TestCase
+{
+    #[Test]
+    public function run_paths_carries_the_selection(): void
+    {
+        $plan = Plan::runPaths(['tests/AaTest.php'], 'one file affected');
+
+        $this->assertSame(['tests/AaTest.php'], $plan->paths());
+        $this->assertSame('one file affected', $plan->reason());
+    }
+
+    /**
+     * The two empty outcomes mean opposite things and must never be conflated:
+     * "nothing to do" exits clean, "cannot narrow" runs everything.
+     */
+    #[Test]
+    public function run_nothing_is_not_run_all(): void
+    {
+        $nothing = Plan::runNothing('no affected test files');
+
+        $this->assertTrue($nothing->isRunNothing());
+        $this->assertFalse($nothing->isRunAll());
+    }
+
+    #[Test]
+    public function run_all_is_not_run_nothing(): void
+    {
+        $all = Plan::runAll('no graph recorded yet');
+
+        $this->assertTrue($all->isRunAll());
+        $this->assertFalse($all->isRunNothing());
+    }
+}

--- a/tests/Cli/SelectionTest.php
+++ b/tests/Cli/SelectionTest.php
@@ -126,10 +126,29 @@ final class SelectionTest extends TestCase
     }
 
     /**
+     * The trait replays a cached result only when it is a success; anything
+     * else runs again. A selector that prunes more eagerly would leave, say, a
+     * test skipped for a missing service unrun indefinitely — the fingerprint
+     * tracks only the PHP version and composer/phpunit files, so starting that
+     * service does not invalidate the graph.
+     */
+    #[Test]
+    public function it_selects_a_file_whose_cached_result_is_not_a_success(): void
+    {
+        $this->recordGraph(TestStatus::skipped('service not available'));
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $plan = (new Selection(Tia::instance()))->plan(['tests/FooTest.php'], []);
+
+        $this->assertSame(['tests/FooTest.php'], $plan->paths());
+    }
+
+    /**
      * Records a graph where tests/FooTest.php covers src/Foo.php, committed so
      * the baseline sha is reachable.
      */
-    private function recordGraph(): void
+    private function recordGraph(?TestStatus $status = null): void
     {
         $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n}\n");
         $this->repo->write('tests/FooTest.php', "<?php\n\nclass FooTest\n{\n}\n");
@@ -138,7 +157,8 @@ final class SelectionTest extends TestCase
 
         $graph = new Graph($this->repo->path());
         $graph->link($this->repo->path().'/tests/FooTest.php', $this->repo->path().'/src/Foo.php');
-        $graph->setResult('main', 'FooTest::test_it_works', TestStatus::success()->asInt(), '', 0.01, 1, 'tests/FooTest.php');
+        $status ??= TestStatus::success();
+        $graph->setResult('main', 'FooTest::test_it_works', $status->asInt(), $status->message(), 0.01, 1, 'tests/FooTest.php');
         $graph->setFingerprint(Fingerprint::compute($this->repo->path()));
         $graph->setRecordedAtSha('main', $sha);
 

--- a/tests/Cli/SelectionTest.php
+++ b/tests/Cli/SelectionTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Tests\Cli;
+
+use JMac\Testing\PhpUnit\Tia\ChangedFiles;
+use JMac\Testing\PhpUnit\Tia\Cli\Selection;
+use JMac\Testing\PhpUnit\Tia\FileState;
+use JMac\Testing\PhpUnit\Tia\Fingerprint;
+use JMac\Testing\PhpUnit\Tia\Graph;
+use JMac\Testing\PhpUnit\Tia\Storage;
+use JMac\Testing\PhpUnit\Tia\Tests\Support\TempGitRepository;
+use JMac\Testing\PhpUnit\Tia\Tia;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestStatus\TestStatus;
+
+/**
+ * Drives the decision table against a real graph in a scratch repo — no
+ * doubles, since the whole point of these cases is that the real impact
+ * analysis feeds the real selection.
+ */
+final class SelectionTest extends TestCase
+{
+    private TempGitRepository $repo;
+
+    protected function setUp(): void
+    {
+        Tia::reset();
+
+        $this->repo = TempGitRepository::create();
+    }
+
+    protected function tearDown(): void
+    {
+        Tia::reset();
+
+        // The rest of the suite dogfoods TIA through this singleton; re-arm it
+        // exactly as Extension::bootstrap() would, as TiaTest does.
+        Tia::configure(dirname(__DIR__, 2), 'global');
+
+        $this->repo->cleanup();
+    }
+
+    #[Test]
+    public function it_runs_everything_when_there_is_no_usable_graph(): void
+    {
+        Tia::configure($this->repo->path(), 'local');
+
+        $plan = (new Selection(Tia::instance()))->plan(['tests/FooTest.php'], []);
+
+        $this->assertTrue($plan->isRunAll());
+    }
+
+    #[Test]
+    public function it_runs_nothing_when_the_graph_is_usable_and_nothing_changed(): void
+    {
+        $this->recordGraph();
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $plan = (new Selection(Tia::instance()))->plan(['tests/FooTest.php'], []);
+
+        $this->assertTrue($plan->isRunNothing());
+    }
+
+    #[Test]
+    public function it_selects_the_test_covering_a_changed_source_file(): void
+    {
+        $this->recordGraph();
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n    public function added(): void {}\n}\n");
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $plan = (new Selection(Tia::instance()))->plan(['tests/FooTest.php'], []);
+
+        $this->assertSame(['tests/FooTest.php'], $plan->paths());
+    }
+
+    /**
+     * A test file the graph has never recorded is in neither the affected set
+     * nor the re-run set, because both are driven by what changed. Selecting
+     * by path would drop it silently and it could stay unrun forever.
+     */
+    #[Test]
+    public function it_always_selects_a_test_file_the_graph_does_not_know(): void
+    {
+        $this->recordGraph();
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $plan = (new Selection(Tia::instance()))->plan(['tests/FooTest.php', 'tests/BrandNewTest.php'], []);
+
+        $this->assertSame(['tests/BrandNewTest.php'], $plan->paths());
+    }
+
+    /**
+     * Positional paths bypass <exclude>, so anything the configured suite
+     * would not run must never be emitted.
+     */
+    #[Test]
+    public function it_never_selects_a_file_the_suite_would_not_run(): void
+    {
+        $this->recordGraph();
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n    public function added(): void {}\n}\n");
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $plan = (new Selection(Tia::instance()))->plan([], []);
+
+        $this->assertTrue($plan->isRunNothing());
+    }
+
+    #[Test]
+    public function it_intersects_with_the_paths_the_user_asked_for(): void
+    {
+        $this->recordGraph();
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n    public function added(): void {}\n}\n");
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $plan = (new Selection(Tia::instance()))->plan(['tests/FooTest.php'], ['tests/Feature']);
+
+        $this->assertTrue($plan->isRunNothing());
+    }
+
+    /**
+     * Records a graph where tests/FooTest.php covers src/Foo.php, committed so
+     * the baseline sha is reachable.
+     */
+    private function recordGraph(): void
+    {
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n}\n");
+        $this->repo->write('tests/FooTest.php', "<?php\n\nclass FooTest\n{\n}\n");
+
+        $sha = $this->repo->commit('add Foo + FooTest');
+
+        $graph = new Graph($this->repo->path());
+        $graph->link($this->repo->path().'/tests/FooTest.php', $this->repo->path().'/src/Foo.php');
+        $graph->setResult('main', 'FooTest::test_it_works', TestStatus::success()->asInt(), '', 0.01, 1, 'tests/FooTest.php');
+        $graph->setFingerprint(Fingerprint::compute($this->repo->path()));
+        $graph->setRecordedAtSha('main', $sha);
+
+        $changedFiles = new ChangedFiles($this->repo->path());
+        $graph->setLastRunTree('main', $changedFiles->snapshotTree(['src/Foo.php', 'tests/FooTest.php']));
+
+        (new FileState(Storage::resolve($this->repo->path(), 'local')))
+            ->write(Storage::GRAPH_KEY, (string) $graph->encode());
+    }
+}

--- a/tests/Cli/SuiteFilesTest.php
+++ b/tests/Cli/SuiteFilesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Tests\Cli;
+
+use JMac\Testing\PhpUnit\Tia\Cli\SuiteFiles;
+use JMac\Testing\PhpUnit\Tia\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\TextUI\CliArguments\Builder as CliBuilder;
+use PHPUnit\TextUI\Configuration\Registry;
+use PHPUnit\TextUI\XmlConfiguration\Loader;
+use ReflectionProperty;
+
+final class SuiteFilesTest extends TestCase
+{
+    private const ROOT = __DIR__.'/../..';
+
+    /**
+     * The binary runs before PHPUnit boots, so it has to populate the
+     * Configuration registry itself. Swapping the process-wide singleton is
+     * restorable, which is the line drawn in GraphTest for the same reason.
+     */
+    private function withProjectConfiguration(callable $assertions): void
+    {
+        $registry = new ReflectionProperty(Registry::class, 'instance');
+        $original = $registry->getValue();
+
+        try {
+            Registry::init(
+                (new CliBuilder)->fromParameters([]),
+                (new Loader)->load(realpath(self::ROOT).'/phpunit.xml.dist'),
+            );
+
+            $assertions();
+        } finally {
+            $registry->setValue(null, $original);
+        }
+    }
+
+    #[Test]
+    public function it_lists_the_test_files_the_configured_suite_would_run(): void
+    {
+        $this->withProjectConfiguration(function (): void {
+            $files = SuiteFiles::fromProjectRoot(realpath(self::ROOT))->all();
+
+            $this->assertContains('tests/GraphTest.php', $files);
+        });
+    }
+
+    /**
+     * Positional paths bypass <exclude>, so an excluded file handed to PHPUnit
+     * runs and can fatal. This list is what makes that unreachable.
+     */
+    #[Test]
+    public function it_omits_files_the_suite_excludes(): void
+    {
+        $this->withProjectConfiguration(function (): void {
+            $files = SuiteFiles::fromProjectRoot(realpath(self::ROOT))->all();
+
+            $this->assertNotContains('tests/fixture-app/tests/WidgetTest.php', $files);
+        });
+    }
+}

--- a/tests/Cli/SuiteFilesTest.php
+++ b/tests/Cli/SuiteFilesTest.php
@@ -38,6 +38,71 @@ final class SuiteFilesTest extends TestCase
         }
     }
 
+    /**
+     * --testsuite restricts the run to named suites, so files from the others
+     * must not be selected. Missing this makes the wrapper run tests the user
+     * excluded, and pulls in every never-recorded file from those suites.
+     */
+    #[Test]
+    public function it_honours_a_testsuite_restriction(): void
+    {
+        $this->withTwoSuiteConfiguration(['--testsuite', 'cli'], function (): void {
+            $files = SuiteFiles::fromProjectRoot(realpath(self::ROOT))->all();
+
+            $this->assertContains('tests/Cli/PlanTest.php', $files);
+            $this->assertNotContains('tests/GraphTest.php', $files);
+        });
+    }
+
+    #[Test]
+    public function it_honours_an_excluded_testsuite(): void
+    {
+        $this->withTwoSuiteConfiguration(['--exclude-testsuite', 'cli'], function (): void {
+            $files = SuiteFiles::fromProjectRoot(realpath(self::ROOT))->all();
+
+            $this->assertNotContains('tests/Cli/PlanTest.php', $files);
+            $this->assertContains('tests/GraphTest.php', $files);
+        });
+    }
+
+    /**
+     * @param  list<string>  $arguments
+     */
+    private function withTwoSuiteConfiguration(array $arguments, callable $assertions): void
+    {
+        $root = realpath(self::ROOT);
+        $file = sys_get_temp_dir().'/phpunit-tia-suites-'.bin2hex(random_bytes(6)).'.xml';
+
+        file_put_contents($file, <<<XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <phpunit bootstrap="{$root}/vendor/autoload.php">
+                <testsuites>
+                    <testsuite name="cli">
+                        <directory>{$root}/tests/Cli</directory>
+                    </testsuite>
+                    <testsuite name="rest">
+                        <directory>{$root}/tests</directory>
+                        <exclude>{$root}/tests/Cli</exclude>
+                        <exclude>{$root}/tests/fixture-app</exclude>
+                    </testsuite>
+                </testsuites>
+            </phpunit>
+            XML);
+
+        $registry = new ReflectionProperty(Registry::class, 'instance');
+        $original = $registry->getValue();
+
+        try {
+            Registry::init((new CliBuilder)->fromParameters($arguments), (new Loader)->load($file));
+
+            $assertions();
+        } finally {
+            $registry->setValue(null, $original);
+
+            @unlink($file);
+        }
+    }
+
     #[Test]
     public function it_lists_the_test_files_the_configured_suite_would_run(): void
     {

--- a/tests/Cli/WrapperEndToEndTest.php
+++ b/tests/Cli/WrapperEndToEndTest.php
@@ -28,6 +28,9 @@ final class WrapperEndToEndTest extends TestCase
     /** @var array<string, string> */
     private array $originalSources = [];
 
+    /** @var list<string> */
+    private array $createdFiles = [];
+
     protected function setUp(): void
     {
         $this->app = dirname(__DIR__).'/fixture-app';
@@ -51,7 +54,12 @@ final class WrapperEndToEndTest extends TestCase
             file_put_contents($path, $contents);
         }
 
+        foreach ($this->createdFiles as $path) {
+            @unlink($path);
+        }
+
         $this->originalSources = [];
+        $this->createdFiles = [];
 
         if (is_dir($this->home)) {
             $this->removeDirectory($this->home);
@@ -121,6 +129,46 @@ final class WrapperEndToEndTest extends TestCase
         $this->assertStringContainsString('OK (1 test', $run->getOutput());
     }
 
+    /**
+     * The trait replays only a cached success, so a test skipped for a missing
+     * service is retried on every run and starts passing once that service is
+     * up. Selection has to agree: the fingerprint tracks the PHP version and
+     * the composer/phpunit files, so starting the service does not invalidate
+     * the graph, and a selector that pruned the file would leave the test
+     * unrun indefinitely.
+     *
+     * The test under measurement writes a marker before skipping itself, so
+     * the marker's presence proves its body actually executed rather than
+     * being replayed or never selected.
+     */
+    #[Test]
+    public function it_reselects_a_test_that_skipped_itself_last_run(): void
+    {
+        $marker = $this->app.'/tia-e2e-marker.txt';
+
+        $this->createFixtureTest('EnvSkippedTest', <<<PHP
+            public function test_it_skips_when_a_service_is_missing(): void
+            {
+                file_put_contents('{$marker}', 'ran');
+
+                \$this->markTestSkipped('service not available');
+            }
+            PHP);
+
+        $this->createdFiles[] = $marker;
+
+        $this->recordBaseline(expectedTests: 4);
+
+        $this->assertFileExists($marker, 'the baseline run should execute the test body');
+
+        unlink($marker);
+
+        $run = $this->wrapper();
+
+        $this->assertFileExists($marker, 'nothing changed, but the skipped test must be selected again');
+        $this->assertStringContainsString('test files selected', $run->getErrorOutput());
+    }
+
     #[Test]
     public function it_runs_the_whole_suite_when_disabled_by_environment(): void
     {
@@ -143,11 +191,42 @@ final class WrapperEndToEndTest extends TestCase
         );
     }
 
-    private function recordBaseline(): void
+    private function recordBaseline(int $expectedTests = 3): void
     {
         $run = $this->process([PHP_BINARY, '-d', 'pcov.enabled=1', '-d', 'pcov.directory=.', 'vendor/bin/phpunit']);
 
-        $this->assertStringContainsString('OK (3 tests', $run->getOutput(), 'baseline run should pass');
+        // PHPUnit reports "OK (N tests, …)" for a clean run but "Tests: N, …"
+        // once anything is skipped, and one case deliberately records a skip.
+        $this->assertMatchesRegularExpression(
+            "/(OK \({$expectedTests} tests|Tests: {$expectedTests}\b)/",
+            $run->getOutput(),
+            'baseline run should cover the whole fixture',
+        );
+    }
+
+    /**
+     * Writes an extra test class into the fixture for the duration of one
+     * case. Keeping it out of the committed fixture matters: a permanently
+     * skipped test would be selected on every run and would break the cases
+     * that assert nothing is affected.
+     */
+    private function createFixtureTest(string $class, string $body): void
+    {
+        $path = $this->app."/tests/{$class}.php";
+
+        file_put_contents($path, <<<PHP
+            <?php
+
+            namespace Tests;
+
+            class {$class} extends TestCase
+            {
+            {$body}
+            }
+
+            PHP);
+
+        $this->createdFiles[] = $path;
     }
 
     private function changeCalculator(): void

--- a/tests/Cli/WrapperEndToEndTest.php
+++ b/tests/Cli/WrapperEndToEndTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Tests\Cli;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * Drives the real binary as a subprocess against tests/fixture-app, a small
+ * project wired exactly as a consumer's would be.
+ *
+ * The unit tests cover each part in isolation; this covers the one thing they
+ * cannot — that the shim, the planner and the re-exec actually compose when
+ * run the way a user runs them.
+ *
+ * Each case gets its own HOME so the graph under test is never the developer's
+ * real one, and the fixture's sources are restored afterwards.
+ */
+final class WrapperEndToEndTest extends TestCase
+{
+    private string $app;
+
+    private string $home;
+
+    /** @var array<string, string> */
+    private array $originalSources = [];
+
+    protected function setUp(): void
+    {
+        $this->app = dirname(__DIR__).'/fixture-app';
+
+        if (! is_file($this->app.'/vendor/autoload.php')) {
+            $this->markTestSkipped('fixture-app dependencies are not installed — run `composer install` in tests/fixture-app.');
+        }
+
+        if (! extension_loaded('pcov') && ! extension_loaded('xdebug')) {
+            $this->markTestSkipped('recording a baseline needs a coverage driver.');
+        }
+
+        $this->home = sys_get_temp_dir().'/phpunit-tia-e2e-'.bin2hex(random_bytes(6));
+
+        mkdir($this->home);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalSources as $path => $contents) {
+            file_put_contents($path, $contents);
+        }
+
+        $this->originalSources = [];
+
+        if (is_dir($this->home)) {
+            $this->removeDirectory($this->home);
+        }
+    }
+
+    #[Test]
+    public function it_runs_the_whole_suite_when_there_is_no_baseline(): void
+    {
+        $run = $this->wrapper();
+
+        $this->assertStringContainsString('no usable baseline graph', $run->getErrorOutput());
+        $this->assertStringContainsString('OK (3 tests', $run->getOutput());
+    }
+
+    #[Test]
+    public function it_runs_nothing_once_the_baseline_is_warm_and_nothing_changed(): void
+    {
+        $this->recordBaseline();
+
+        $run = $this->wrapper();
+
+        $this->assertSame(0, $run->getExitCode());
+        $this->assertStringContainsString('nothing affected', $run->getErrorOutput());
+        $this->assertStringNotContainsString('OK (', $run->getOutput());
+    }
+
+    #[Test]
+    public function it_selects_only_the_test_files_covering_a_changed_source(): void
+    {
+        $this->recordBaseline();
+        $this->changeCalculator();
+
+        $run = $this->wrapper();
+
+        $this->assertStringContainsString('1 of 2 test files selected', $run->getErrorOutput());
+        $this->assertStringContainsString('OK (2 tests', $run->getOutput());
+    }
+
+    /**
+     * The trait can only skip, so --fail-on-skipped forces it to give up its
+     * speed-up entirely and run everything. Selecting up front produces no
+     * skips at all, so the flag and the speed-up finally coexist.
+     */
+    #[Test]
+    public function it_keeps_the_speed_up_under_fail_on_skipped(): void
+    {
+        $this->recordBaseline();
+        $this->changeCalculator();
+
+        $run = $this->wrapper(['--fail-on-skipped']);
+
+        $this->assertSame(0, $run->getExitCode());
+        $this->assertStringContainsString('1 of 2 test files selected', $run->getErrorOutput());
+        $this->assertStringContainsString('OK (2 tests', $run->getOutput());
+    }
+
+    #[Test]
+    public function it_passes_options_through_to_the_real_runner(): void
+    {
+        $this->recordBaseline();
+        $this->changeCalculator();
+
+        $run = $this->wrapper(['--filter', 'test_it_adds']);
+
+        $this->assertStringContainsString('1 of 2 test files selected', $run->getErrorOutput());
+        $this->assertStringContainsString('OK (1 test', $run->getOutput());
+    }
+
+    #[Test]
+    public function it_runs_the_whole_suite_when_disabled_by_environment(): void
+    {
+        $this->recordBaseline();
+
+        $run = $this->wrapper(env: ['PHPUNIT_TIA' => '0']);
+
+        $this->assertStringContainsString('OK (3 tests', $run->getOutput());
+    }
+
+    /**
+     * @param  list<string>  $arguments
+     * @param  array<string, string>  $env
+     */
+    private function wrapper(array $arguments = [], array $env = []): Process
+    {
+        return $this->process(
+            [PHP_BINARY, 'vendor/bin/phpunit-tia', ...$arguments],
+            $env,
+        );
+    }
+
+    private function recordBaseline(): void
+    {
+        $run = $this->process([PHP_BINARY, '-d', 'pcov.enabled=1', '-d', 'pcov.directory=.', 'vendor/bin/phpunit']);
+
+        $this->assertStringContainsString('OK (3 tests', $run->getOutput(), 'baseline run should pass');
+    }
+
+    private function changeCalculator(): void
+    {
+        $path = $this->app.'/src/Calculator.php';
+        $this->originalSources[$path] = (string) file_get_contents($path);
+
+        $contents = $this->originalSources[$path];
+        $position = strrpos($contents, '}');
+
+        file_put_contents($path, substr($contents, 0, $position)
+            ."\n    public function triple(int \$number): int\n    {\n        return \$number * 3;\n    }\n"
+            .substr($contents, $position));
+    }
+
+    /**
+     * @param  list<string>  $command
+     * @param  array<string, string>  $env
+     */
+    private function process(array $command, array $env = []): Process
+    {
+        $process = new Process($command, $this->app, ['HOME' => $this->home] + $env, timeout: 120);
+
+        $process->run();
+
+        return $process;
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        foreach ((array) scandir($directory) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $directory.'/'.$entry;
+
+            is_dir($path) ? $this->removeDirectory($path) : @unlink($path);
+        }
+
+        @rmdir($directory);
+    }
+}

--- a/tests/TiaTest.php
+++ b/tests/TiaTest.php
@@ -228,6 +228,40 @@ final class TiaTest extends TestCase
     }
 
     /**
+     * The selection wrapper has to tell "active, but nothing is affected"
+     * apart from "could not narrow at all" — the first means run nothing, the
+     * second means run everything. Both look like an empty affected set.
+     */
+    #[Test]
+    public function it_is_not_active_without_a_recorded_graph(): void
+    {
+        Tia::configure($this->repo->path(), 'local');
+
+        $this->assertFalse(Tia::instance()->isActive());
+    }
+
+    #[Test]
+    public function it_is_active_once_a_graph_is_recorded(): void
+    {
+        $this->recordPassingTest();
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $this->assertTrue(Tia::instance()->isActive());
+    }
+
+    #[Test]
+    public function it_exposes_the_affected_test_files(): void
+    {
+        $this->recordPassingTest();
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n    public function added(): void {}\n}\n");
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $this->assertSame(['tests/FooTest.php'], Tia::instance()->affectedTestFiles());
+    }
+
+    /**
      * @return array{0: string, 1: string, 2: string} [className, methodName, sha]
      */
     private function recordPassingTest(?string $sha = null, ?array $fingerprint = null): array


### PR DESCRIPTION
Closes #4 — implements the first roadmap item. Opening it as a review target, not as a claim on your time: if the answer is still "not now", closing this costs nothing.

The trait can only skip inside `setUp()`, so an unaffected `TestCase` is still constructed and its data providers still resolve. `vendor/bin/phpunit-tia` computes the impacted set *before* PHPUnit boots and re-execs the real runner with only those files.

Measured on a large private Laravel application — 3,385 tests in the suite under test, warm baseline, nothing changed:

| | |
|---|---|
| no TIA, full run | 135s |
| `vendor/bin/phpunit` (trait) | **11.9s** — 3,385 constructed, 3,250 skipped |
| `vendor/bin/phpunit-tia` | **0.23s** — nothing constructed |

**53× over the trait**, on top of the 11× the trait already gives. Planning costs 85ms (config load + `Registry::init`) plus 4ms of `git diff`.

**Where it does *not* help, measured on the same app.** With one `app/` file edited, the wrapper selected 4 of 139 files and ran 65 tests, against the trait constructing all 3,385 and running 194:

| | |
|---|---|
| trait, one source changed | 17.8s |
| wrapper, one source changed | **16.8s** — 4 of 139 files, 65 tests |

Barely a win, because once real tests must run, their execution dominates and the construction the wrapper avoids is noise beside it. The large multipliers appear when little or nothing is impacted — which, in a tight edit-run loop, is most runs.

The saving is exactly the work PHPUnit does *before* `setUp()`: constructing each case and running data providers, which execute at suite-build time whether a test later skips or not. The trait cannot avoid that; it can only skip once already inside `setUp()`. It is also bounded below by PHPUnit's own startup, which neither escapes. On this repo's suite the same comparison is 1.53s → 0.13s, and on a synthetic project of trivial one-line tests it nearly vanishes — there the trait is actually slower than no TIA at all, its bookkeeping outweighing the bodies it skips.

So treat any single multiplier as that suite's number. The rule underneath: the more expensive your tests are to build, and the less often your edits touch them, the more this is worth.

## Usage

Drop-in for `vendor/bin/phpunit`. Every option is passed through untouched and applies *within* the impacted set — options narrow, they never widen:

```sh
vendor/bin/phpunit-tia                              # impacted tests only
vendor/bin/phpunit-tia --filter it_creates_a_widget # impacted, then filtered
vendor/bin/phpunit-tia --stop-on-failure --testdox  # any phpunit flags
```

A path narrows the selection rather than replacing it, and combines with options:

```sh
vendor/bin/phpunit-tia tests/Feature                # impacted within tests/Feature
vendor/bin/phpunit-tia --filter Widget tests/Feature
```

The existing escape hatches behave exactly as they do for the trait, running the full suite with your arguments untouched:

```sh
PHPUNIT_TIA=0 vendor/bin/phpunit-tia --filter PlanTest
PHPUNIT_TIA_FRESH=1 vendor/bin/phpunit-tia
```

One new variable, `PHPUNIT_TIA_BINARY`, points at the `phpunit` to re-exec for projects whose Composer `bin-dir` isn't `vendor/bin`. Defaults to `vendor/bin/phpunit`.

Observed on this repo, with one behavioural edit to `src/Cli/Plan.php`:

```
$ vendor/bin/phpunit-tia
phpunit-tia: 2 of 18 test files selected.
OK (9 tests, 12 assertions)

$ vendor/bin/phpunit-tia --filter run_paths_carries
phpunit-tia: 2 of 18 test files selected.
OK (1 test, 2 assertions)
```

Impact is judged behaviourally, so a comment-only edit to the same file reports `nothing affected` and runs nothing — inherited from `ChangedFiles`, not new here.

## The run set

```
( affected ∪ mustRerun ∪ (onDisk \ graphKnown) ) ∩ onDisk ∩ userPaths
```

Every term is load-bearing, and two are less obvious:

**`onDisk \ graphKnown`** — a test file the graph has never recorded. `affected()` is driven purely by what changed, so such a file is in neither of the first two terms. That's harmless for the trait, which runs anything it has no cached result for, but a path-based selector would drop it silently and could leave it unrun indefinitely. This is the one that would have made the feature unsafe.

**`∩ onDisk`** — positional paths bypass `<testsuite><exclude>`. Handing PHPUnit an excluded file runs it; in this repo `phpunit tests/fixture-app/tests` fatals with `Class "Tests\TestCase" not found`. Intersecting with the suite's own enumeration (the same `FileIterator` call `TestSuiteMapper` makes) makes that unreachable.

## Safety

Everything uncertain runs the full suite: no baseline, fingerprint change, unreachable baseline sha, a must-rerun test with no resolvable file, or any unexpected throwable. "Nothing to run" is kept distinct from "cannot narrow", because `phpunit` with no positional paths runs *everything* — collapsing the two would turn a no-op into a full run, or a full run into a silent no-op.

Selection is by file; the trait keeps filtering by method inside the files that do run, so they compose rather than overlap.

## Notes for review

- Five accessors added to `Tia` (`isActive`, `affectedTestFiles`, `testFilesToRerun`, `hasUnlocatedTestsToRerun`, `knownTestFiles`) so the binary reuses the existing analysis rather than reimplementing it. No behaviour change.
- Nothing outside `src/Cli/` depends on `src/Cli/`, so the extension and trait stay usable standalone, as the roadmap asked.
- The binary reads the extension's `storage` parameter from your config, so both resolve the same storage directory.
- 163 → 180 tests, 267 assertions, green. Pint passes.

## `--fail-on-skipped` now works with the speed-up, and is tested

The README documents that `--fail-on-skipped` and `--display-skipped` bypass TIA's speed-up. That is accurate for the trait, which can only skip, and that flag turns skips into failures. Selecting up front produces no skips at all, so the two finally coexist — in `tests/fixture-app`:

```
trait   + --fail-on-skipped:  OK (3 tests)                        ← full run, no saving
wrapper + --fail-on-skipped:  1 of 2 test files selected, OK (2 tests)  ← saving kept
```

I have deliberately **not** edited that README caveat: it describes the trait, and it is still true there. Say the word if you want it qualified to mention the binary.

## A bug this found, before you do

Trying it on that application surfaced one immediately: the suite enumeration ignored `--testsuite` and `--exclude-testsuite`. A run narrowed to one suite still saw the others' files, and since a never-recorded file is always selected, it dragged in every unrecorded file from the suites the user had excluded. Reported as `373 of 512 test files selected` where 139 files were in the requested suite — worse than plain `phpunit`, and wrong besides, since it ran tests that were explicitly excluded.

Fixed by applying `includeTestSuites()` / `excludeTestSuites()` before enumerating, which is what `TestSuiteMapper` does. Same case now reports `nothing affected`, with regression tests for both flags.

## One thing I'd flag rather than hide

**The end-to-end tests need `tests/fixture-app`'s own dependencies**, which were never installed, so this PR adds a CI step that runs `composer install` there. Without it the six subprocess tests skip and CI would report green while covering none of this path. That is a change to your workflow file, so it is an easy thing to object to — the tests degrade to skipping if you would rather drop the step.
