### PR TITLE
Stop advancing TIA's baseline on partial runs

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMac\Testing\PhpUnit\Tia;
 
+use JMac\Testing\PhpUnit\Tia\Subscribers\RecordExecutionAborted;
 use JMac\Testing\PhpUnit\Tia\Subscribers\RecordTestConsideredRisky;
 use JMac\Testing\PhpUnit\Tia\Subscribers\RecordTestErrored;
 use JMac\Testing\PhpUnit\Tia\Subscribers\RecordTestFailed;
@@ -57,6 +58,7 @@ final class Extension implements ExtensionContract
         $facade->requireCodeCoverageCollection();
 
         $results = new ResultCollector;
+        $scope = new RunScope;
 
         $facade->registerSubscribers(
             new RecordTestPrepared($results),
@@ -67,7 +69,8 @@ final class Extension implements ExtensionContract
             new RecordTestMarkedIncomplete($results),
             new RecordTestConsideredRisky($results),
             new RecordTestFinished($results),
-            new WriteGraph($projectRoot, $results, $storageMode),
+            new RecordExecutionAborted($scope),
+            new WriteGraph($projectRoot, $results, $storageMode, $scope),
         );
     }
 

--- a/src/RunScope.php
+++ b/src/RunScope.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia;
+
+/**
+ * Whether this run was cut short mid-suite (`--stop-on-failure`/`--stop-on-error`/etc.,
+ * or Ctrl-C) rather than completing everything it started. Set by
+ * Subscribers\RecordExecutionAborted from PHPUnit\Event\TestRunner\ExecutionAborted,
+ * which PHPUnit's TestSuite::run() always emits before ExecutionFinished in that case —
+ * so Subscribers\WriteGraph::isPartialRun() can tell the difference between "nothing
+ * left to run" and "stopped before finishing" when deciding whether this run is
+ * authoritative enough to advance the baseline.
+ */
+final class RunScope
+{
+    private bool $aborted = false;
+
+    public function abort(): void
+    {
+        $this->aborted = true;
+    }
+
+    public function wasAborted(): bool
+    {
+        return $this->aborted;
+    }
+}

--- a/src/Subscribers/RecordExecutionAborted.php
+++ b/src/Subscribers/RecordExecutionAborted.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\PhpUnit\Tia\Subscribers;
+
+use JMac\Testing\PhpUnit\Tia\RunScope;
+use PHPUnit\Event\TestRunner\ExecutionAborted;
+use PHPUnit\Event\TestRunner\ExecutionAbortedSubscriber;
+
+final readonly class RecordExecutionAborted implements ExecutionAbortedSubscriber
+{
+    public function __construct(private RunScope $scope) {}
+
+    public function notify(ExecutionAborted $event): void
+    {
+        $this->scope->abort();
+    }
+}

--- a/src/Subscribers/WriteGraph.php
+++ b/src/Subscribers/WriteGraph.php
@@ -11,11 +11,13 @@ use JMac\Testing\PhpUnit\Tia\Fingerprint;
 use JMac\Testing\PhpUnit\Tia\Graph;
 use JMac\Testing\PhpUnit\Tia\Recorder;
 use JMac\Testing\PhpUnit\Tia\ResultCollector;
+use JMac\Testing\PhpUnit\Tia\RunScope;
 use JMac\Testing\PhpUnit\Tia\Storage;
 use JMac\Testing\PhpUnit\Tia\Tia;
 use PHPUnit\Event\TestRunner\ExecutionFinished;
 use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
 use PHPUnit\Runner\CodeCoverage;
+use PHPUnit\TextUI\Configuration\Registry;
 
 /**
  * The one piece of Pest's Tia.php orchestration this milestone needs:
@@ -31,6 +33,7 @@ final readonly class WriteGraph implements ExecutionFinishedSubscriber
         private string $projectRoot,
         private ResultCollector $results,
         private string $storageMode,
+        private RunScope $scope,
     ) {}
 
     public function notify(ExecutionFinished $event): void
@@ -84,16 +87,53 @@ final readonly class WriteGraph implements ExecutionFinishedSubscriber
         $graph->pruneMissingTests();
 
         $graph->setFingerprint($currentFingerprint);
-        $graph->setRecordedAtSha($branch, $changedFiles->currentSha());
-        $graph->setLastRunTree($branch, $changedFiles->snapshotTree(
-            array_values(array_unique([...$graph->allTestFiles(), ...$graph->allSourceFiles()])),
-        ));
+
+        // A narrowed or aborted run only tells us about the files its own tests
+        // touched, not about every other file this snapshot would otherwise cover —
+        // advancing the baseline here would "bank" unverified edits as already-seen
+        // (see the doc comment on isPartialRun()). Leave both pointers at whatever
+        // the last authoritative run left them.
+        if (! $this->isPartialRun()) {
+            $graph->setRecordedAtSha($branch, $changedFiles->currentSha());
+            $graph->setLastRunTree($branch, $changedFiles->snapshotTree(
+                array_values(array_unique([...$graph->allTestFiles(), ...$graph->allSourceFiles()])),
+            ));
+        }
 
         $encoded = $graph->encode();
 
         if ($encoded !== null) {
             $state->write(Storage::GRAPH_KEY, $encoded);
         }
+    }
+
+    /**
+     * Whether this run isn't authoritative for "every known file not touched this
+     * run is unchanged" — either because it was narrowed to less than the full
+     * configured suite (`--filter`, `--group`, `--testsuite`, or an explicit path
+     * argument), or because it was cut short before finishing (`--stop-on-*`, or
+     * Ctrl-C via RunScope — see that class's doc comment). A narrowed/aborted run
+     * still executed real tests, whose results/edges are recorded as usual; only
+     * the baseline pointers that claim to describe the *whole* tracked file set
+     * are held back.
+     */
+    private function isPartialRun(): bool
+    {
+        if ($this->scope->wasAborted()) {
+            return true;
+        }
+
+        $configuration = Registry::get();
+
+        return $configuration->hasFilter()
+            || $configuration->hasExcludeFilter()
+            || $configuration->hasTestIdFilter()
+            || $configuration->hasTestIdFilterFile()
+            || $configuration->hasGroups()
+            || $configuration->hasExcludeGroups()
+            || $configuration->includeTestSuites() !== []
+            || $configuration->excludeTestSuites() !== []
+            || $configuration->hasCliArguments();
     }
 
     /**

--- a/tests/WriteGraphTest.php
+++ b/tests/WriteGraphTest.php
@@ -9,13 +9,19 @@ use JMac\Testing\PhpUnit\Tia\FileState;
 use JMac\Testing\PhpUnit\Tia\Fingerprint;
 use JMac\Testing\PhpUnit\Tia\Graph;
 use JMac\Testing\PhpUnit\Tia\ResultCollector;
+use JMac\Testing\PhpUnit\Tia\RunScope;
 use JMac\Testing\PhpUnit\Tia\Storage;
 use JMac\Testing\PhpUnit\Tia\Subscribers\WriteGraph;
 use JMac\Testing\PhpUnit\Tia\Tests\Support\TempGitRepository;
 use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestStatus\TestStatus;
+use PHPUnit\TextUI\CliArguments\Builder as CliBuilder;
+use PHPUnit\TextUI\Configuration\Registry;
+use PHPUnit\TextUI\XmlConfiguration\DefaultConfiguration;
 use ReflectionClass;
+use ReflectionProperty;
 
 /**
  * Covers the write side end to end: load the on-disk graph, fold in this
@@ -98,6 +104,7 @@ final class WriteGraphTest extends TestCase
         $this->assertTrue($status->isSuccess());
         $this->assertSame(4, $graph->getAssertions('main', $testId));
         $this->assertNotNull($graph->recordedAtSha('main'));
+        $this->assertNotSame([], $graph->lastRunTree('main'), 'A full run must snapshot the tree.');
     }
 
     /**
@@ -205,6 +212,98 @@ final class WriteGraphTest extends TestCase
         $this->assertNull($this->persistedGraph()->getResult('main', $stale));
     }
 
+    /**
+     * A run narrowed by `--filter`/`--group`/`--testsuite`/an explicit path only
+     * tells us about the files its own tests touched — advancing the baseline sha
+     * or re-snapshotting the tree here would "bank" whatever changed in the
+     * meantime as already-seen, even though nothing verified it. The test that
+     * *did* run must still be recorded, though.
+     *
+     * @param  list<string>  $cliArguments
+     */
+    #[Test]
+    #[DataProvider('narrowingCliArguments')]
+    public function it_leaves_the_baseline_alone_on_a_narrowed_run(array $cliArguments): void
+    {
+        [$seededSha, $testId] = $this->seedNarrowableBaseline(
+            self::class.'::it_leaves_the_baseline_alone_on_a_narrowed_run',
+        );
+
+        $this->notify($this->resultsFor($testId), cliArguments: $cliArguments);
+
+        $this->assertBaselineWasLeftAlone($seededSha, $testId);
+    }
+
+    /**
+     * `fromParameters()` mirrors real `$argv`, where index 0 is the invoked
+     * program itself, not the first argument — `SebastianBergmann\CliParser`
+     * unconditionally shifts off whatever doesn't start with `-` in that slot.
+     * A leading `'phpunit'` keeps a bare path argument from being swallowed as
+     * if it were that program name.
+     *
+     * @return array<string, array{list<string>}>
+     */
+    public static function narrowingCliArguments(): array
+    {
+        return [
+            '--filter' => [['phpunit', '--filter=Foo']],
+            '--group' => [['phpunit', '--group=slow']],
+            '--testsuite' => [['phpunit', '--testsuite=unit']],
+            'explicit path' => [['phpunit', 'tests/FooTest.php']],
+        ];
+    }
+
+    /**
+     * Mirrors the narrowed-run case above, but for a run PHPUnit cut short itself
+     * (`--stop-on-failure`/etc., or Ctrl-C) rather than one narrowed by CLI flags —
+     * RunScope is how Subscribers\RecordExecutionAborted reports that.
+     */
+    #[Test]
+    public function it_leaves_the_baseline_alone_on_an_aborted_run(): void
+    {
+        [$seededSha, $testId] = $this->seedNarrowableBaseline(
+            self::class.'::it_leaves_the_baseline_alone_on_an_aborted_run',
+        );
+
+        $scope = new RunScope;
+        $scope->abort();
+
+        $this->notify($this->resultsFor($testId), $scope);
+
+        $this->assertBaselineWasLeftAlone($seededSha, $testId);
+    }
+
+    /**
+     * Seeds a baseline, stamps it with a recorded sha and a tree snapshot, then
+     * commits an unrelated edit after that — the point a full run's baseline
+     * would legitimately move past, and a narrowed/aborted run's must not.
+     *
+     * @return array{0: ?string, 1: string} the seeded sha and the test ID to report this run
+     */
+    private function seedNarrowableBaseline(string $testId): array
+    {
+        $this->seedBaselineWith([]);
+        $seededSha = (new ChangedFiles($this->repo->path()))->currentSha();
+
+        $graph = $this->persistedGraph();
+        $graph->setLastRunTree('main', ['src/Foo.php' => 'stale-hash']);
+        $this->state()->write(Storage::GRAPH_KEY, (string) $graph->encode());
+
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n    public function bar(): void {}\n}\n");
+        $this->repo->commit('unrelated edit');
+
+        return [$seededSha, $testId];
+    }
+
+    private function assertBaselineWasLeftAlone(?string $seededSha, string $testId): void
+    {
+        $graph = $this->persistedGraph();
+
+        $this->assertSame($seededSha, $graph->recordedAtSha('main'), 'The baseline sha must not advance.');
+        $this->assertSame(['src/Foo.php' => 'stale-hash'], $graph->lastRunTree('main'), 'The tree must not be re-snapshotted.');
+        $this->assertNotNull($graph->getResult('main', $testId), 'The test that actually ran must still be recorded.');
+    }
+
     private function resultsFor(string $testId): ResultCollector
     {
         $results = new ResultCollector;
@@ -244,11 +343,33 @@ final class WriteGraphTest extends TestCase
      * value that is then discarded, so instantiate it without its constructor
      * instead.
      */
-    private function notify(ResultCollector $results): void
+    /**
+     * `WriteGraph::isPartialRun()` reads the process-wide `Registry::get()`
+     * Configuration, so leaving it at whatever the *outer* `phpunit` invocation
+     * running this test suite happened to use (e.g. someone's IDE running this
+     * one test via `--filter`) would make these tests pass or fail depending on
+     * how they're invoked. Pin it to a known, unnarrowed Configuration by
+     * default — same swap-and-restore approach GraphTest.php already uses —
+     * and let callers opt into a narrowed one via $cliArguments.
+     *
+     * @param  list<string>  $cliArguments  Passed through fromParameters(); a leading
+     *                                      'phpunit' avoids the parser swallowing a lone
+     *                                      positional argument as the program name.
+     */
+    private function notify(ResultCollector $results, ?RunScope $scope = null, array $cliArguments = ['phpunit']): void
     {
         $event = (new ReflectionClass(ExecutionFinished::class))->newInstanceWithoutConstructor();
 
-        (new WriteGraph($this->repo->path(), $results, 'local'))->notify($event);
+        $registry = new ReflectionProperty(Registry::class, 'instance');
+        $original = $registry->getValue();
+
+        try {
+            Registry::init((new CliBuilder)->fromParameters($cliArguments), DefaultConfiguration::create());
+
+            (new WriteGraph($this->repo->path(), $results, 'local', $scope ?? new RunScope))->notify($event);
+        } finally {
+            $registry->setValue(null, $original);
+        }
     }
 
     private function persistedGraph(): Graph


### PR DESCRIPTION
TIA keeps a baseline of what it's already checked — a snapshot of file contents plus the commit it last looked at — so on the next run it only has to look at what changed since then, instead of re-verifying everything. A review comment on #5 flagged several problems with that baseline; this fixes the most serious one.

Currently, TIA updates that baseline after every run, even one that only looked at part of the suite — a `--filter`, `--group`, `--testsuite`, an explicit path, or a run `--stop-on-failure` or Ctrl-C cut short partway through. Whatever those runs happened to see gets folded into the baseline as if it had actually been checked.

Right now, that means you can edit a file, run a narrower slice of tests, and then run the full suite later without the edit ever getting verified. TIA already "saw" that file's new content during the narrow run and marked it accounted for, so the full run trusts that and skips the test that should have caught a regression there. `git status` still shows the file changed; TIA doesn't. There's no warning — only wiping the whole cache clears it, and it's easy not to realize you need to.

Now TIA only updates the baseline after a run that covers everything it's tracking. A narrower or interrupted run still records whatever it actually checked, same as before — it just no longer gets to vouch for the rest of the codebase it never looked at.
