### PR TITLE
Merge edges instead of replacing them per run

### DIFF
--- a/src/Graph.php
+++ b/src/Graph.php
@@ -102,6 +102,18 @@ final class Graph
     }
 
     /**
+     * Folds this run's recorded coverage into each test file's edge set —
+     * merged in, not replaced. A coverage session only reports what actually
+     * executed, and TIA's entire point is to skip cached-passing tests
+     * (§4.7): a file with one skipped method and one freshly-run method would
+     * otherwise have this run's data *replace* its whole edge list, silently
+     * dropping the skipped method's still-valid source dependencies and
+     * narrowing its regression window. Same false-positive-is-cheap,
+     * false-negative-is-fatal reasoning as applyUnknownSourceDirs() below: a
+     * stale edge just costs an extra re-run later; a dropped one defeats TIA.
+     * `PHPUNIT_TIA_FRESH=1` (loadGraph() in Subscribers\WriteGraph) is the
+     * existing escape hatch for clearing accumulated staleness.
+     *
      * @param  array<string, array<int, string>>  $testToFiles
      */
     public function replaceEdges(array $testToFiles): void
@@ -113,13 +125,11 @@ final class Graph
                 continue;
             }
 
-            $this->edges[$testRel] = [];
-
             foreach ($sources as $source) {
                 $this->link($testFile, $source);
             }
 
-            $this->edges[$testRel] = array_values(array_unique($this->edges[$testRel]));
+            $this->edges[$testRel] = array_values(array_unique($this->edges[$testRel] ?? []));
         }
     }
 

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -491,15 +491,18 @@ final class GraphTest extends TestCase
     }
 
     /**
-     * The name is the contract: the incoming set replaces that test file's
-     * edges rather than adding to them, and duplicates within one payload
-     * collapse.
+     * A coverage session only reports what actually executed. When only some
+     * of a file's tests run this session (the common case — TIA skips
+     * cached-passing ones), this call's payload must add to the file's edge
+     * set rather than replace it, or the skipped tests' still-valid source
+     * dependencies would silently drop out and narrow that file's regression
+     * window. Duplicates within one payload still collapse.
      */
     #[Test]
-    public function replace_edges_overwrites_the_previous_edge_set_for_a_test_file(): void
+    public function replace_edges_merges_into_the_previous_edge_set_for_a_test_file(): void
     {
         // Separate directories on purpose: the sibling-directory fallback
-        // would otherwise bridge the dropped edge and mask the overwrite.
+        // would otherwise bridge the two edges and mask a wrongful overwrite.
         $this->repo->write('src/Foo.php', "<?php\n");
         $this->repo->write('lib/Bar.php', "<?php\n");
         $this->repo->write('tests/FooTest.php', "<?php\n");
@@ -511,7 +514,11 @@ final class GraphTest extends TestCase
 
         $this->assertSame(['tests/FooTest.php'], $graph->allTestFiles());
         $this->assertSame(['tests/FooTest.php'], $graph->affected(['lib/Bar.php']));
-        $this->assertSame([], $graph->affected(['src/Foo.php']));
+        $this->assertSame(
+            ['tests/FooTest.php'],
+            $graph->affected(['src/Foo.php']),
+            'The edge recorded before this session must survive a session that never touched it.',
+        );
     }
 
     /**


### PR DESCRIPTION
TIA remembers which tests touch which source files — call that link between a test and the file it covers an "edge" — so it knows what to skip and what to rerun when something changes. A review comment on #5 flagged several problems with that memory; this fixes one of them.

Currently, TIA skips tests it's already confident are passing — that's the whole point of the tool. But it only knew what a test file covered from whatever ran in the current session, so a file with one test skipped as already-passing and one that actually ran had its known coverage rewritten down to just what the running test touched — discarding what TIA already knew about the skipped one.

Right now, when you edit a file, the test meant to catch a regression there might not rerun, because TIA has already forgotten it ever depended on that file. No warning, nothing to notice — the change just slips through. This wasn't rare; it happened on nearly every normal run, since skipping known-good tests is exactly what TIA is built to do.

Now TIA keeps what it already knew and adds to it, rather than throwing it away every run. A file that genuinely stops being covered by a test (say, after a refactor) won't get cleaned out of the graph automatically — worst case that's an occasional unnecessary rerun, a much safer failure than a missed regression. `PHPUNIT_TIA_FRESH=1` still resets everything if that ever needs a clean slate.
