### PR TITLE
Add PHPUNIT_TIA_DEBUG to explain skip decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ PHPUNIT_TIA_FRESH=1 phpunit ...
 
 **Note:** running tests with the `--fail-on-skipped` or `--display-skipped` option will automatically bypass TIA's speed boost. You will need to drop these options to take full advantage of TIA.
 
+### Debugging a test that won't skip
+If a test keeps running when you expect TIA to skip it, pass an environment variable to have TIA explain why on STDERR, one line per test that actually ran:
+
+```sh
+PHPUNIT_TIA_DEBUG=1 phpunit ...
+```
+
+```
+TIA-DEBUG: running Tests\FooTest::test_it_works — source changed: src/Foo.php
+```
+
+A common cause: TIA's change detection includes `git status`, so any file a test run writes back into the project tree (a fixture database, a generated upload, a cache directory) looks "changed" on every run if it isn't `.gitignore`d — and can mark every test that shares its directory as affected. If the reported reason names a file you didn't intentionally edit, `.gitignore` it and re-run.
+
 ## CI Workflows
 To use TIA in CI, your baseline graph must persist between runs. See our own [GitHub Action workflow](.github/workflows/tests.yml) for an example. At a high level, your workflow needs to:
 

--- a/src/ChangedFiles.php
+++ b/src/ChangedFiles.php
@@ -37,6 +37,11 @@ final class ChangedFiles
         $remaining = [];
 
         foreach (array_keys($candidates) as $file) {
+            // array_keys() casts purely-numeric path segments back to int
+            // (PHP's normal array-key coercion) — restore the string so
+            // callers with `string $path` params under strict_types don't
+            // choke on a numeric-looking file name.
+            $file = (string) $file;
             $snapshot = $lastRunTree[$file] ?? null;
             $current = $this->currentHash($file);
 
@@ -114,7 +119,11 @@ final class ChangedFiles
             $unique[$file] = true;
         }
 
-        $candidates = array_keys($this->filterIgnored($unique));
+        // array_keys() casts purely-numeric path segments back to int (PHP's
+        // normal array-key coercion) — restore the string so callers with
+        // `string $path` params under strict_types don't choke on a
+        // numeric-looking file name.
+        $candidates = array_map(strval(...), array_keys($this->filterIgnored($unique)));
 
         if ($sha !== null && $sha !== '') {
             return $this->filterBehaviourallyUnchanged($candidates, $sha);

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -211,9 +211,13 @@ final class Graph
 
     /**
      * @param  array<int, string>  $changedFiles  Absolute or relative paths.
+     * @param  array<string, string>  $reasons  Out-param (§ diagnostics): project-relative test
+     *                                          file => human-readable reason it was marked affected.
+     *                                          First pass to mark a given test wins, mirroring the
+     *                                          `isset($affectedSet[...])` short-circuiting below.
      * @return array<int, string>
      */
-    public function affected(array $changedFiles): array
+    public function affected(array $changedFiles, array &$reasons = []): array
     {
         $relPaths = [];
 
@@ -229,11 +233,12 @@ final class Graph
         $testPaths = $this->testPaths ?? TestPaths::fromProjectRoot($this->projectRoot);
 
         $affectedSet = [];
+        $reasons = [];
 
-        $unknown = $this->applyPhpEdgeChanges($relPaths, $testPaths, $affectedSet);
-        $this->applyTestFileChanges($relPaths, $testPaths, $affectedSet);
-        $this->applyUnknownSourceDirs($unknown, $affectedSet);
-        $this->applyResolvers($unknown, $affectedSet);
+        $unknown = $this->applyPhpEdgeChanges($relPaths, $testPaths, $affectedSet, $reasons);
+        $this->applyTestFileChanges($relPaths, $testPaths, $affectedSet, $reasons);
+        $this->applyUnknownSourceDirs($unknown, $affectedSet, $reasons);
+        $this->applyResolvers($unknown, $affectedSet, $reasons);
 
         return array_keys($affectedSet);
     }
@@ -246,16 +251,20 @@ final class Graph
      *
      * @param  list<string>  $relPaths
      * @param  array<string, true>  $affectedSet
+     * @param  array<string, string>  $reasons
      * @return list<string>
      */
-    private function applyPhpEdgeChanges(array $relPaths, TestPaths $testPaths, array &$affectedSet): array
+    private function applyPhpEdgeChanges(array $relPaths, TestPaths $testPaths, array &$affectedSet, array &$reasons): array
     {
         $changedIds = [];
         $unknown = [];
 
         foreach ($relPaths as $rel) {
             if (isset($this->fileIds[$rel])) {
-                $changedIds[$this->fileIds[$rel]] = true;
+                // Value is the changed file's own relative path, not just a
+                // marker: a matched source id and a changed file's id are the
+                // same file here, so it doubles as the diagnostic reason below.
+                $changedIds[$this->fileIds[$rel]] = $rel;
 
                 continue;
             }
@@ -278,6 +287,7 @@ final class Graph
             foreach ($ids as $id) {
                 if (isset($changedIds[$id])) {
                     $affectedSet[$testFile] = true;
+                    $reasons[$testFile] = "source changed: {$changedIds[$id]}";
 
                     break;
                 }
@@ -293,8 +303,9 @@ final class Graph
      *
      * @param  list<string>  $relPaths
      * @param  array<string, true>  $affectedSet
+     * @param  array<string, string>  $reasons
      */
-    private function applyTestFileChanges(array $relPaths, TestPaths $testPaths, array &$affectedSet): void
+    private function applyTestFileChanges(array $relPaths, TestPaths $testPaths, array &$affectedSet, array &$reasons): void
     {
         foreach ($relPaths as $rel) {
             if (isset($affectedSet[$rel])) {
@@ -310,6 +321,7 @@ final class Graph
             }
 
             $affectedSet[$rel] = true;
+            $reasons[$rel] = 'test file itself changed';
         }
     }
 
@@ -325,8 +337,9 @@ final class Graph
      *
      * @param  list<string>  $unknown
      * @param  array<string, true>  $affectedSet
+     * @param  array<string, string>  $reasons
      */
-    private function applyUnknownSourceDirs(array $unknown, array &$affectedSet): void
+    private function applyUnknownSourceDirs(array $unknown, array &$affectedSet, array &$reasons): void
     {
         if ($unknown === []) {
             return;
@@ -335,7 +348,9 @@ final class Graph
         $unknownDirs = [];
 
         foreach ($unknown as $rel) {
-            $unknownDirs[dirname($rel)] = true;
+            // Last writer wins when two unknown files share a directory —
+            // fine for a diagnostic example, doesn't affect which tests match.
+            $unknownDirs[dirname($rel)] = $rel;
         }
 
         foreach ($this->edges as $testFile => $ids) {
@@ -348,8 +363,11 @@ final class Graph
                     continue;
                 }
 
-                if (isset($unknownDirs[dirname($this->files[$id])])) {
+                $dir = dirname($this->files[$id]);
+
+                if (isset($unknownDirs[$dir])) {
                     $affectedSet[$testFile] = true;
+                    $reasons[$testFile] = "unresolved change '{$unknownDirs[$dir]}' shares a directory with covered source '{$this->files[$id]}'";
 
                     break;
                 }
@@ -366,8 +384,9 @@ final class Graph
      *
      * @param  list<string>  $unknown
      * @param  array<string, true>  $affectedSet
+     * @param  array<string, string>  $reasons
      */
-    private function applyResolvers(array $unknown, array &$affectedSet): void
+    private function applyResolvers(array $unknown, array &$affectedSet, array &$reasons): void
     {
         if ($unknown === [] || $this->resolvers === []) {
             return;
@@ -380,6 +399,7 @@ final class Graph
 
                     if ($testRel !== null) {
                         $affectedSet[$testRel] = true;
+                        $reasons[$testRel] ??= 'resolver '.$resolver::class." matched changed file '{$rel}'";
                     }
                 }
             }

--- a/src/Tia.php
+++ b/src/Tia.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace JMac\Testing\PhpUnit\Tia;
 
 use PHPUnit\Framework\TestStatus\TestStatus;
-use ReflectionClass;
+use ReflectionMethod;
 use Throwable;
 
 /**
@@ -114,8 +114,13 @@ final class Tia
             return null;
         }
 
+        // ReflectionMethod, not ReflectionClass: must match the file PHPUnit itself
+        // recorded the edge under (TestMethodBuilder → Reflection::sourceLocationFor),
+        // which is the method's *declaring* file. For a test inherited from an
+        // abstract fixture, that's the fixture's file, not the concrete subclass's —
+        // using ReflectionClass here would never find the edge Recorder wrote.
         try {
-            $file = (new ReflectionClass($class))->getFileName();
+            $file = (new ReflectionMethod($class, self::methodNameOnly($method)))->getFileName();
         } catch (Throwable) {
             return null;
         }
@@ -173,13 +178,13 @@ final class Tia
         }
 
         try {
-            $file = (new ReflectionClass($class))->getFileName();
+            $file = (new ReflectionMethod($class, self::methodNameOnly($method)))->getFileName();
         } catch (Throwable) {
-            return 'test class could not be reflected';
+            return 'test method could not be reflected';
         }
 
         if ($file === false) {
-            return "test class has no resolvable file (e.g. eval()'d code)";
+            return "test method has no resolvable file (e.g. eval()'d code)";
         }
 
         if (! $this->graph->knowsTest($file)) {
@@ -207,6 +212,16 @@ final class Tia
         }
 
         return "a skip would violate this run's fail-on-skipped/display-skipped (or similar) policy";
+    }
+
+    /**
+     * RunWithTia passes `methodName#dataSetName` as $method to key data-provided
+     * results in the graph, but that composite isn't a real declared method —
+     * ReflectionMethod needs just the method name to find where it's declared.
+     */
+    private static function methodNameOnly(string $method): string
+    {
+        return explode('#', $method, 2)[0];
     }
 
     private static function boot(): self

--- a/src/Tia.php
+++ b/src/Tia.php
@@ -36,13 +36,23 @@ final class Tia
     /** @var array<string, true> project-relative test file => affected */
     private array $affectedTestFiles;
 
+    /** @var array<string, string> project-relative test file => why it was marked affected (§ diagnostics) */
+    private array $affectedReasons;
+
+    /**
+     * @param  array<string, true>  $affectedTestFiles
+     * @param  array<string, string>  $affectedReasons
+     */
     private function __construct(
         private readonly bool $active,
         private readonly ?Graph $graph,
         private readonly string $branch,
         array $affectedTestFiles,
+        array $affectedReasons = [],
+        private readonly ?string $inactiveReason = null,
     ) {
         $this->affectedTestFiles = $affectedTestFiles;
+        $this->affectedReasons = $affectedReasons;
     }
 
     /**
@@ -83,6 +93,12 @@ final class Tia
     public static function isFresh(): bool
     {
         return getenv('PHPUNIT_TIA_FRESH') === '1';
+    }
+
+    /** `PHPUNIT_TIA_DEBUG=1` — have {@see Traits\RunWithTia} report why each non-skipped test ran. */
+    public static function isDebug(): bool
+    {
+        return getenv('PHPUNIT_TIA_DEBUG') === '1';
     }
 
     /**
@@ -143,10 +159,68 @@ final class Tia
         return $this->graph?->recordedAtSha($this->branch);
     }
 
+    /**
+     * `PHPUNIT_TIA_DEBUG=1` companion to {@see cachedStatusIfUnaffected()} —
+     * called by the trait only once it's already decided *not* to skip, to
+     * explain why. Mirrors that method's own early-return structure so the
+     * two stay in lockstep, but returns a reason string at each branch
+     * instead of `null`.
+     */
+    public function debugReason(string $class, string $method): string
+    {
+        if (! $this->active || $this->graph === null) {
+            return $this->inactiveReason ?? 'TIA inactive this run';
+        }
+
+        try {
+            $file = (new ReflectionClass($class))->getFileName();
+        } catch (Throwable) {
+            return 'test class could not be reflected';
+        }
+
+        if ($file === false) {
+            return "test class has no resolvable file (e.g. eval()'d code)";
+        }
+
+        if (! $this->graph->knowsTest($file)) {
+            return 'not yet recorded (new or never-run test)';
+        }
+
+        $relative = $this->graph->relativePath($file);
+
+        if ($relative === null) {
+            return 'test file is outside the project root';
+        }
+
+        if (isset($this->affectedTestFiles[$relative])) {
+            return $this->affectedReasons[$relative] ?? 'marked affected';
+        }
+
+        $status = $this->graph->getResult($this->branch, $class.'::'.$method);
+
+        if ($status === null) {
+            return 'no cached result yet';
+        }
+
+        if (! $status->isSuccess()) {
+            return "cached status was {$status->asString()}, only cached passes replay";
+        }
+
+        return "a skip would violate this run's fail-on-skipped/display-skipped (or similar) policy";
+    }
+
     private static function boot(): self
     {
-        if (! self::$configured || self::$projectRoot === null || ! self::isEnabled() || self::isFresh()) {
-            return self::inactive();
+        if (! self::$configured || self::$projectRoot === null) {
+            return self::inactive('TIA is not configured for this run');
+        }
+
+        if (! self::isEnabled()) {
+            return self::inactive('disabled via PHPUNIT_TIA=0');
+        }
+
+        if (self::isFresh()) {
+            return self::inactive('PHPUNIT_TIA_FRESH=1 — baseline is being rebuilt this run');
         }
 
         try {
@@ -154,7 +228,7 @@ final class Tia
         } catch (Throwable) {
             // A TIA replay failure must never break the underlying test
             // suite — fall back to letting every test actually run.
-            return self::inactive();
+            return self::inactive('an internal error occurred while loading the TIA graph');
         }
     }
 
@@ -167,13 +241,13 @@ final class Tia
         $raw = $state->read(Storage::GRAPH_KEY);
 
         if ($raw === null) {
-            return self::inactive();
+            return self::inactive('no stored graph yet (looks like the first run)');
         }
 
         $graph = Graph::decode($raw, $projectRoot);
 
         if ($graph === null) {
-            return self::inactive();
+            return self::inactive('stored graph could not be decoded (corrupt, or from an unsupported schema version)');
         }
 
         $graph->setResolvers($resolvers);
@@ -181,11 +255,11 @@ final class Tia
         $current = Fingerprint::compute($projectRoot);
 
         if (! Fingerprint::structuralMatches($graph->fingerprint(), $current)) {
-            return self::inactive();
+            return self::inactive('composer.lock/phpunit.xml changed since the stored graph was written');
         }
 
         if (Fingerprint::environmentalDrift($graph->fingerprint(), $current) !== []) {
-            return self::inactive();
+            return self::inactive('the environment (e.g. PHP version) drifted since the stored graph was written');
         }
 
         $changedFiles = new ChangedFiles($projectRoot);
@@ -195,16 +269,19 @@ final class Tia
         if ($changed === null) {
             // Baseline sha isn't reachable from HEAD (rebase, force-push) —
             // the diff can't be trusted, so don't replay anything this run.
-            return self::inactive();
+            return self::inactive('baseline commit is not reachable from HEAD (rebase/force-push?) — the diff cannot be trusted');
         }
 
         $changed = $changedFiles->filterUnchangedSinceLastRun($changed, $graph->lastRunTree($branch));
 
-        return new self(true, $graph, $branch, array_fill_keys($graph->affected($changed), true));
+        $reasons = [];
+        $affected = $graph->affected($changed, $reasons);
+
+        return new self(true, $graph, $branch, array_fill_keys($affected, true), $reasons);
     }
 
-    private static function inactive(): self
+    private static function inactive(?string $reason = null): self
     {
-        return new self(false, null, 'default', []);
+        return new self(false, null, 'default', [], [], $reason);
     }
 }

--- a/src/Traits/RunWithTia.php
+++ b/src/Traits/RunWithTia.php
@@ -29,6 +29,13 @@ trait RunWithTia
                 'TIA: unaffected since %s, last run passed',
                 $tia->recordedAtSha() ?? 'unknown',
             ));
+        } elseif (Tia::isDebug()) {
+            fwrite(STDERR, sprintf(
+                "TIA-DEBUG: running %s::%s — %s\n",
+                static::class,
+                $method,
+                $tia->debugReason(static::class, $method),
+            ));
         }
 
         parent::setUp();

--- a/tests/ChangedFilesTest.php
+++ b/tests/ChangedFilesTest.php
@@ -185,6 +185,37 @@ final class ChangedFilesTest extends TestCase
     }
 
     #[Test]
+    public function since_returns_string_paths_for_purely_numeric_filenames(): void
+    {
+        // PHP casts an array key to int when the key string is a canonical
+        // decimal integer (digits only, no extension or other characters).
+        // since() collects git-status paths as array keys before returning
+        // them via array_keys() — a bare numeric filename would otherwise
+        // come back as an int, breaking callers with `string $path` params.
+        $this->repo->write('123', "<?php\n");
+
+        $changed = $this->changedFiles->since(null);
+
+        $this->assertSame(['123'], $changed);
+        $this->assertIsString($changed[0]);
+    }
+
+    #[Test]
+    public function filter_unchanged_since_last_run_returns_string_paths_for_purely_numeric_filenames(): void
+    {
+        $this->repo->write('123', "<?php\nfinal class Foo {}\n");
+        $this->repo->commit('add 123');
+
+        $remaining = $this->changedFiles->filterUnchangedSinceLastRun(
+            ['123'],
+            ['123' => 'stale-hash'],
+        );
+
+        $this->assertSame(['123'], $remaining);
+        $this->assertIsString($remaining[0]);
+    }
+
+    #[Test]
     public function snapshot_tree_hashes_each_file(): void
     {
         $this->repo->write('src/Foo.php', "<?php\nfinal class Foo {}\n");

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -70,7 +70,9 @@ final class GraphTest extends TestCase
         $graph->link('tests/FooTest.php', 'src/Foo.php');
         $graph->link('tests/BarTest.php', 'src/Bar.php');
 
-        $this->assertSame(['tests/FooTest.php'], $graph->affected(['src/Foo.php']));
+        $reasons = [];
+        $this->assertSame(['tests/FooTest.php'], $graph->affected(['src/Foo.php'], $reasons));
+        $this->assertSame(['tests/FooTest.php' => 'source changed: src/Foo.php'], $reasons);
     }
 
     #[Test]
@@ -80,7 +82,9 @@ final class GraphTest extends TestCase
 
         $graph = $this->graph();
 
-        $this->assertSame(['tests/FooTest.php'], $graph->affected(['tests/FooTest.php']));
+        $reasons = [];
+        $this->assertSame(['tests/FooTest.php'], $graph->affected(['tests/FooTest.php'], $reasons));
+        $this->assertSame(['tests/FooTest.php' => 'test file itself changed'], $reasons);
     }
 
     #[Test]
@@ -96,7 +100,12 @@ final class GraphTest extends TestCase
         $graph = $this->graph();
         $graph->link('tests/FooTest.php', 'app/Listeners/Foo.php');
 
-        $this->assertSame(['tests/FooTest.php'], $graph->affected(['app/Listeners/Bar.php']));
+        $reasons = [];
+        $this->assertSame(['tests/FooTest.php'], $graph->affected(['app/Listeners/Bar.php'], $reasons));
+        $this->assertSame(
+            ['tests/FooTest.php' => "unresolved change 'app/Listeners/Bar.php' shares a directory with covered source 'app/Listeners/Foo.php'"],
+            $reasons,
+        );
     }
 
     #[Test]
@@ -120,9 +129,16 @@ final class GraphTest extends TestCase
         $graph = $this->graph();
         $graph->setResolvers([$resolver]);
 
+        $reasons = [];
         $this->assertSame(
             ['tests/WidgetTest.php'],
-            $graph->affected(['database/migrations/2024_01_01_create_widgets_table.php']),
+            $graph->affected(['database/migrations/2024_01_01_create_widgets_table.php'], $reasons),
+        );
+        $this->assertArrayHasKey('tests/WidgetTest.php', $reasons);
+        $this->assertStringContainsString($resolver::class, $reasons['tests/WidgetTest.php']);
+        $this->assertStringContainsString(
+            "matched changed file 'database/migrations/2024_01_01_create_widgets_table.php'",
+            $reasons['tests/WidgetTest.php'],
         );
     }
 
@@ -131,7 +147,9 @@ final class GraphTest extends TestCase
     {
         $graph = $this->graph();
 
-        $this->assertSame([], $graph->affected(['src/LongGoneNeverCovered.php']));
+        $reasons = [];
+        $this->assertSame([], $graph->affected(['src/LongGoneNeverCovered.php'], $reasons));
+        $this->assertSame([], $reasons);
     }
 
     #[Test]

--- a/tests/RunWithTiaTest.php
+++ b/tests/RunWithTiaTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\SkippedWithMessageException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestStatus\TestStatus;
+use Symfony\Component\Process\Process;
 
 /**
  * Exercises RunWithTia::setUp() directly against a scratch repo with a
@@ -140,6 +141,89 @@ final class RunWithTiaTest extends TestCase
         $fixture->setUp();
 
         $this->assertSame(0, $fixture->numberOfAssertionsPerformed());
+    }
+
+    /**
+     * PHPUNIT_TIA_DEBUG=1 (§ diagnostics) has RunWithTia::setUp() write a
+     * `TIA-DEBUG:` line to STDERR explaining why a non-skipped test ran.
+     * fwrite(STDERR, ...) can't be intercepted in-process, so this shells
+     * out to a real PHP process running the fixture directly (Symfony\Process
+     * is already a dependency, used the same way by ChangedFilesTest et al.
+     * for git plumbing).
+     */
+    #[Test]
+    public function it_writes_a_debug_line_to_stderr_when_a_non_skipped_test_runs(): void
+    {
+        $this->recordPassingResult();
+
+        // Real token change (not just whitespace/comments — see TiaTest) so
+        // the test is not skipped.
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n    public int \$x = 1;\n}\n");
+
+        $errorOutput = $this->runFixtureInSubprocess(debug: true);
+
+        $this->assertStringContainsString(
+            "TIA-DEBUG: running {$this->fixtureClass}::test_it_works — source changed: src/Foo.php",
+            $errorOutput,
+        );
+    }
+
+    #[Test]
+    public function it_writes_nothing_to_stderr_when_debug_mode_is_off(): void
+    {
+        $this->recordPassingResult();
+
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n    public int \$x = 1;\n}\n");
+
+        $this->assertSame('', $this->runFixtureInSubprocess(debug: false));
+    }
+
+    #[Test]
+    public function it_writes_nothing_to_stderr_when_the_test_is_skipped(): void
+    {
+        $this->recordPassingResult();
+
+        $this->assertSame('', $this->runFixtureInSubprocess(debug: true));
+    }
+
+    private function runFixtureInSubprocess(bool $debug): string
+    {
+        $script = sprintf(
+            <<<'PHP'
+            <?php
+            require %s;
+            require %s;
+
+            JMac\Testing\PhpUnit\Tia\Tia::configure(%s, 'local');
+
+            $fixture = new %s('test_it_works');
+
+            try {
+                // setUp() is protected; called here from the global scope
+                // rather than a sibling TestCase subclass (as the in-process
+                // tests below do), so it needs Reflection to bypass that.
+                (new ReflectionMethod($fixture, 'setUp'))->invoke($fixture);
+            } catch (\Throwable) {
+                // A TIA skip throws — that's fine, we only care about STDERR.
+            }
+
+            PHP,
+            var_export(dirname(__DIR__).'/vendor/autoload.php', true),
+            var_export($this->repo->path().'/tests/FixtureUsingTia.php', true),
+            var_export($this->repo->path(), true),
+            $this->fixtureClass,
+        );
+
+        $scriptPath = $this->repo->path().'/debug_probe.php';
+        file_put_contents($scriptPath, $script);
+
+        $process = new Process(
+            [PHP_BINARY, $scriptPath],
+            env: $debug ? ['PHPUNIT_TIA_DEBUG' => '1'] : ['PHPUNIT_TIA_DEBUG' => false],
+        );
+        $process->run();
+
+        return $process->getErrorOutput();
     }
 
     private function recordPassingResult(int $assertions = 3): string

--- a/tests/TiaTest.php
+++ b/tests/TiaTest.php
@@ -103,6 +103,56 @@ final class TiaTest extends TestCase
     }
 
     #[Test]
+    public function it_replays_a_test_inherited_from_an_abstract_fixture_class(): void
+    {
+        // Regression for #9: a concrete test class that declares no test
+        // methods of its own, inheriting them all from an abstract fixture,
+        // must still replay. PHPUnit itself records the edge under the
+        // *fixture's* file (Reflection::sourceLocationFor reflects the
+        // method's declaring class), so the replay lookup has to resolve the
+        // same way rather than reflecting the concrete subclass.
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n}\n");
+
+        $method = 'test_it_works';
+        $fixtureClass = 'TiaFixtureAbstract'.bin2hex(random_bytes(6));
+        $this->repo->write(
+            'tests/EmailQueueFixture.php',
+            "<?php\n\nabstract class {$fixtureClass}\n{\n    public function {$method}(): void {}\n}\n",
+        );
+        require $this->repo->path().'/tests/EmailQueueFixture.php';
+
+        $concreteClass = 'TiaFixtureConcrete'.bin2hex(random_bytes(6));
+        $this->repo->write(
+            'tests/FooTest.php',
+            "<?php\n\nclass {$concreteClass} extends {$fixtureClass}\n{\n}\n",
+        );
+        require $this->repo->path().'/tests/FooTest.php';
+
+        $sha = $this->repo->commit('add Foo + fixture + concrete subclass');
+
+        $graph = new Graph($this->repo->path());
+        // Edge keyed by the fixture file — matching what PHPUnit's own
+        // TestMethodBuilder records for an inherited test method.
+        $graph->link($this->repo->path().'/tests/EmailQueueFixture.php', $this->repo->path().'/src/Foo.php');
+        $graph->setResult('main', $concreteClass.'::'.$method, TestStatus::success()->asInt(), '', 0.01, 1, 'tests/EmailQueueFixture.php');
+        $graph->setFingerprint(Fingerprint::compute($this->repo->path()));
+        $graph->setRecordedAtSha('main', $sha);
+
+        $changedFiles = new ChangedFiles($this->repo->path());
+        $graph->setLastRunTree('main', $changedFiles->snapshotTree(['src/Foo.php', 'tests/EmailQueueFixture.php', 'tests/FooTest.php']));
+
+        $state = new FileState(Storage::resolve($this->repo->path(), 'local'));
+        $state->write(Storage::GRAPH_KEY, (string) $graph->encode());
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $status = Tia::instance()->cachedStatusIfUnaffected($concreteClass, $method);
+
+        $this->assertNotNull($status);
+        $this->assertTrue($status->isSuccess());
+    }
+
+    #[Test]
     public function it_does_not_replay_a_test_whose_source_file_changed(): void
     {
         [$class, $method] = $this->recordPassingTest();
@@ -125,7 +175,7 @@ final class TiaTest extends TestCase
 
         Tia::configure($this->repo->path(), 'local');
 
-        $unknownClass = $this->defineFixtureClass('tests/UnknownTest.php');
+        $unknownClass = $this->defineFixtureClass('tests/UnknownTest.php', ['test_something']);
 
         $this->assertNull(Tia::instance()->cachedStatusIfUnaffected($unknownClass, 'test_something'));
     }
@@ -285,7 +335,7 @@ final class TiaTest extends TestCase
 
         Tia::configure($this->repo->path(), 'local');
 
-        $unknownClass = $this->defineFixtureClass('tests/UnknownTest.php');
+        $unknownClass = $this->defineFixtureClass('tests/UnknownTest.php', ['test_something']);
 
         $this->assertSame(
             'not yet recorded (new or never-run test)',
@@ -346,7 +396,7 @@ final class TiaTest extends TestCase
     private function recordTest(TestStatus $status, ?string $sha = null, ?array $fingerprint = null): array
     {
         $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n}\n");
-        $class = $this->defineFixtureClass('tests/FooTest.php');
+        $class = $this->defineFixtureClass('tests/FooTest.php', ['test_it_works', 'test_a_different_method_never_run']);
         $method = 'test_it_works';
 
         $recordedSha = $this->repo->commit('add Foo + FooTest');
@@ -366,10 +416,18 @@ final class TiaTest extends TestCase
         return [$class, $method, $sha ?? $recordedSha];
     }
 
-    private function defineFixtureClass(string $relativePath): string
+    /**
+     * @param  list<string>  $methods  Real method names to declare on the fixture class —
+     *                                 Tia now resolves a test's file via ReflectionMethod
+     *                                 (to match how PHPUnit itself records the edge), so
+     *                                 callers must reflect an actual declared method, not
+     *                                 just a class.
+     */
+    private function defineFixtureClass(string $relativePath, array $methods = ['test_it_works']): string
     {
         $class = 'TiaFixture'.bin2hex(random_bytes(6));
-        $this->repo->write($relativePath, "<?php\n\nclass {$class}\n{\n}\n");
+        $body = implode('', array_map(static fn (string $method) => "    public function {$method}(): void {}\n", $methods));
+        $this->repo->write($relativePath, "<?php\n\nclass {$class}\n{\n{$body}}\n");
         require $this->repo->path().'/'.$relativePath;
 
         return $class;

--- a/tests/TiaTest.php
+++ b/tests/TiaTest.php
@@ -227,6 +227,111 @@ final class TiaTest extends TestCase
         $this->assertSame(0, Tia::instance()->cachedAssertionCount('AnyClass', 'any_method'));
     }
 
+    #[Test]
+    public function is_debug_reflects_the_env_var(): void
+    {
+        $this->assertFalse(Tia::isDebug());
+
+        putenv('PHPUNIT_TIA_DEBUG=1');
+
+        try {
+            $this->assertTrue(Tia::isDebug());
+        } finally {
+            putenv('PHPUNIT_TIA_DEBUG');
+        }
+    }
+
+    #[Test]
+    public function debug_reason_reports_when_never_configured(): void
+    {
+        $this->assertSame(
+            'TIA is not configured for this run',
+            Tia::instance()->debugReason('AnyClass', 'any_method'),
+        );
+    }
+
+    #[Test]
+    public function debug_reason_reports_disabled_via_env(): void
+    {
+        [$class, $method] = $this->recordPassingTest();
+
+        putenv('PHPUNIT_TIA=0');
+
+        try {
+            Tia::configure($this->repo->path(), 'local');
+            $this->assertSame('disabled via PHPUNIT_TIA=0', Tia::instance()->debugReason($class, $method));
+        } finally {
+            putenv('PHPUNIT_TIA');
+        }
+    }
+
+    #[Test]
+    public function debug_reason_names_the_changed_source_file(): void
+    {
+        [$class, $method] = $this->recordPassingTest();
+
+        // Same real-token change as it_does_not_replay_a_test_whose_source_file_changed().
+        $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n    public int \$x = 1;\n}\n");
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $this->assertSame('source changed: src/Foo.php', Tia::instance()->debugReason($class, $method));
+    }
+
+    #[Test]
+    public function debug_reason_reports_a_test_unknown_to_the_graph(): void
+    {
+        $this->recordPassingTest();
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $unknownClass = $this->defineFixtureClass('tests/UnknownTest.php');
+
+        $this->assertSame(
+            'not yet recorded (new or never-run test)',
+            Tia::instance()->debugReason($unknownClass, 'test_something'),
+        );
+    }
+
+    #[Test]
+    public function debug_reason_reports_a_non_success_cached_status(): void
+    {
+        [$class, $method] = $this->recordTest(TestStatus::failure('boom'));
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $this->assertSame(
+            'cached status was failure, only cached passes replay',
+            Tia::instance()->debugReason($class, $method),
+        );
+    }
+
+    #[Test]
+    public function debug_reason_reports_no_cached_result_yet(): void
+    {
+        [$class] = $this->recordPassingTest();
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $this->assertSame(
+            'no cached result yet',
+            Tia::instance()->debugReason($class, 'test_a_different_method_never_run'),
+        );
+    }
+
+    #[Test]
+    public function debug_reason_names_the_policy_that_would_force_a_rerun_of_a_known_unaffected_pass(): void
+    {
+        [$class, $method] = $this->recordPassingTest();
+
+        Tia::configure($this->repo->path(), 'local');
+
+        $this->assertSame(
+            "a skip would violate this run's fail-on-skipped/display-skipped (or similar) policy",
+            Tia::instance()->debugReason($class, $method),
+        );
+    }
+
     /**
      * @return array{0: string, 1: string, 2: string} [className, methodName, sha]
      */


### PR DESCRIPTION
TIA skips a test once it's confident that test still passes, deciding that by tracing which source files the test covers and checking whether any of them changed since the recorded baseline.

Right now that decision is silent either way. A skip at least carries a message; an actual run explains nothing, even though the reasoning already exists inside the impact analysis at the moment it's made — a changed file matched a known dependency, or an unresolved change shared a directory with one, or a resolver claimed it, or TIA wasn't even active for the run. That reasoning is just thrown away once the yes/no answer is decided.

So when a test keeps running instead of skipping, there's nothing to go on. You can't tell whether it's genuinely affected, by which file, or through which of TIA's several matching paths — a direct dependency, the sibling-directory fallback for files with no recorded coverage, a resolver.

Set `PHPUNIT_TIA_DEBUG=1` and TIA now says why on STDERR for every test it actually runs, naming the specific changed file and which matching path caught it — or the boot-level reason (no baseline recorded yet, the environment drifted, the recorded commit isn't reachable) when TIA wasn't active for the whole run.

One pattern worth knowing while debugging with this: TIA's change detection includes `git status`, so anything a test run writes back into the project tree without being gitignored — a fixture database, a generated upload — reads as changed on every run, and can drag in every test sharing that directory through the sibling fallback. That's exactly the kind of thing the new output will now point at directly.

---
Closes #9
