### PR TITLE
Allow the baseline fallback branch to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Next, register the extension in your PHPUnit configuration:
 ```
 
 
+When the current branch has no baseline of its own, TIA falls back to `main`
+by default. To use another branch, add the `fallback-branch` parameter:
+
+```xml
+<parameter name="fallback-branch" value="develop"/>
+```
+
+The fallback branch is used only for reading cached results, the recorded
+commit, and the last-run tree. New results are still recorded under the
+current branch.
+
 ## Usage
 To enable TIA, add the trait to your base `TestCase`:
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -32,6 +32,7 @@ final class Extension implements ExtensionContract
 
         $projectRoot = $this->projectRoot($configuration);
         $storageMode = $this->storageMode($parameters);
+        $fallbackBranch = $this->fallbackBranch($parameters);
         $resolvers = Config::loadResolvers($projectRoot);
 
         // Configure the replay side unconditionally, before the driver check
@@ -39,7 +40,7 @@ final class Extension implements ExtensionContract
         // tests needs no coverage driver at all, only recording new edges
         // does. This lets RunWithTia keep working on a machine that lost its
         // driver after the graph was written elsewhere (e.g. CI vs. local).
-        Tia::configure($projectRoot, $storageMode, $resolvers);
+        Tia::configure($projectRoot, $storageMode, $resolvers, $fallbackBranch);
 
         if (! $this->coverageDriverAvailable()) {
             fwrite(STDERR, "phpunit-tia: no coverage driver (pcov/xdebug) available — recording disabled for this run.\n");
@@ -121,5 +122,23 @@ final class Extension implements ExtensionContract
         }
 
         return 'global';
+    }
+
+    /**
+     * <parameter name="fallback-branch" value="develop"/> — the branch whose
+     * baseline is read when the current branch has none of its own. Defaults
+     * to Graph::DEFAULT_FALLBACK_BRANCH.
+     *
+     * Passed through verbatim — trimming and the empty => default
+     * substitution belong to Tia::configure(), the single choke point every
+     * entry point already goes through.
+     */
+    private function fallbackBranch(ParameterCollection $parameters): string
+    {
+        if (! $parameters->has('fallback-branch')) {
+            return Graph::DEFAULT_FALLBACK_BRANCH;
+        }
+
+        return $parameters->get('fallback-branch');
     }
 }

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -21,6 +21,14 @@ use PHPUnit\TextUI\Configuration\Registry;
  */
 final class Graph
 {
+    /**
+     * The branch whose baseline is read when the current branch has none of
+     * its own. Lives here rather than in Tia/Extension because Graph is the
+     * only class that actually consults it — the others just pass a
+     * configured value through.
+     */
+    public const string DEFAULT_FALLBACK_BRANCH = 'main';
+
     private const int SCHEMA_VERSION = 1;
 
     /** @var array<int, string> */
@@ -54,6 +62,8 @@ final class Graph
 
     private ?TestPaths $testPaths = null;
 
+    private string $fallbackBranch = self::DEFAULT_FALLBACK_BRANCH;
+
     public function __construct(string $projectRoot)
     {
         $real = @realpath($projectRoot);
@@ -81,6 +91,18 @@ final class Graph
     public function setTestPaths(?TestPaths $testPaths): void
     {
         $this->testPaths = $testPaths;
+    }
+
+    /**
+     * Expects an already-normalized branch name — Tia::configure() is the one
+     * place trimming and the empty => DEFAULT_FALLBACK_BRANCH substitution
+     * happen, since every entry point funnels through it. An untrimmed value
+     * here wouldn't error, it would just never match a baseline key, silently
+     * disabling the fallback.
+     */
+    public function setFallbackBranch(string $fallbackBranch): void
+    {
+        $this->fallbackBranch = $fallbackBranch;
     }
 
     public function link(string $testFile, string $sourceFile): void
@@ -406,9 +428,9 @@ final class Graph
         }
     }
 
-    public function recordedAtSha(string $branch, string $fallbackBranch = 'main'): ?string
+    public function recordedAtSha(string $branch): ?string
     {
-        return $this->baselineFor($branch, $fallbackBranch)['sha'];
+        return $this->baselineFor($branch)['sha'];
     }
 
     public function setRecordedAtSha(string $branch, ?string $sha): void
@@ -439,16 +461,16 @@ final class Graph
         $this->baselines[$branch]['results'][$testId] = $entry;
     }
 
-    public function getAssertions(string $branch, string $testId, string $fallbackBranch = 'main'): ?int
+    public function getAssertions(string $branch, string $testId): ?int
     {
-        $baseline = $this->baselineFor($branch, $fallbackBranch);
+        $baseline = $this->baselineFor($branch);
 
         return $baseline['results'][$testId]['assertions'] ?? null;
     }
 
-    public function getResult(string $branch, string $testId, string $fallbackBranch = 'main'): ?TestStatus
+    public function getResult(string $branch, string $testId): ?TestStatus
     {
-        $baseline = $this->baselineFor($branch, $fallbackBranch);
+        $baseline = $this->baselineFor($branch);
 
         if (! isset($baseline['results'][$testId])) {
             return null;
@@ -473,9 +495,9 @@ final class Graph
     /**
      * @return array<int, string>
      */
-    public function testFilesToRerun(string $branch, string $fallbackBranch = 'main'): array
+    public function testFilesToRerun(string $branch): array
     {
-        $baseline = $this->baselineFor($branch, $fallbackBranch);
+        $baseline = $this->baselineFor($branch);
         $files = [];
 
         foreach ($baseline['results'] as $result) {
@@ -499,9 +521,9 @@ final class Graph
         return array_keys($files);
     }
 
-    public function hasUnlocatedTestsToRerun(string $branch, string $fallbackBranch = 'main'): bool
+    public function hasUnlocatedTestsToRerun(string $branch): bool
     {
-        $baseline = $this->baselineFor($branch, $fallbackBranch);
+        $baseline = $this->baselineFor($branch);
 
         foreach ($baseline['results'] as $result) {
             if (! $this->shouldRerun($result['status'])) {
@@ -602,22 +624,22 @@ final class Graph
     /**
      * @return array<string, string>
      */
-    public function lastRunTree(string $branch, string $fallbackBranch = 'main'): array
+    public function lastRunTree(string $branch): array
     {
-        return $this->baselineFor($branch, $fallbackBranch)['tree'];
+        return $this->baselineFor($branch)['tree'];
     }
 
     /**
      * @return array{sha: ?string, tree: array<string, string>, results: array<string, array{status: int, message: string, time: float, assertions?: int, file?: string}>}
      */
-    private function baselineFor(string $branch, string $fallbackBranch): array
+    private function baselineFor(string $branch): array
     {
         if (isset($this->baselines[$branch])) {
             return $this->baselines[$branch];
         }
 
-        if ($branch !== $fallbackBranch && isset($this->baselines[$fallbackBranch])) {
-            return $this->baselines[$fallbackBranch];
+        if ($branch !== $this->fallbackBranch && isset($this->baselines[$this->fallbackBranch])) {
+            return $this->baselines[$this->fallbackBranch];
         }
 
         return ['sha' => null, 'tree' => [], 'results' => []];

--- a/src/Tia.php
+++ b/src/Tia.php
@@ -26,6 +26,8 @@ final class Tia
 
     private static string $storageMode = 'global';
 
+    private static string $fallbackBranch = Graph::DEFAULT_FALLBACK_BRANCH;
+
     /** @var list<Contracts\Resolver> */
     private static array $resolvers = [];
 
@@ -61,13 +63,31 @@ final class Tia
      *                                               file (Config::loadResolvers()) since PHPUnit's own
      *                                               flat-string ParameterCollection can't express a list.
      */
-    public static function configure(string $projectRoot, string $storageMode = 'global', array $resolvers = []): void
-    {
+    public static function configure(
+        string $projectRoot,
+        string $storageMode = 'global',
+        array $resolvers = [],
+        string $fallbackBranch = Graph::DEFAULT_FALLBACK_BRANCH,
+    ): void {
         self::$projectRoot = $projectRoot;
         self::$storageMode = $storageMode;
         self::$resolvers = $resolvers;
+        self::$fallbackBranch = self::normalizeFallbackBranch($fallbackBranch);
         self::$configured = true;
         self::$instance = null;
+    }
+
+    /**
+     * Both entry points — Extension's `fallback-branch` XML parameter and any
+     * direct configure() call — pass through here, so Graph and everything
+     * downstream can trust a trimmed, non-empty branch name. Normalizing in
+     * Extension instead would leave direct callers unnormalized.
+     */
+    private static function normalizeFallbackBranch(string $fallbackBranch): string
+    {
+        $trimmed = trim($fallbackBranch);
+
+        return $trimmed !== '' ? $trimmed : Graph::DEFAULT_FALLBACK_BRANCH;
     }
 
     /** Test seam: drop back to the unconfigured state between test cases that touch this singleton. */
@@ -75,6 +95,7 @@ final class Tia
     {
         self::$projectRoot = null;
         self::$storageMode = 'global';
+        self::$fallbackBranch = Graph::DEFAULT_FALLBACK_BRANCH;
         self::$resolvers = [];
         self::$configured = false;
         self::$instance = null;
@@ -239,7 +260,12 @@ final class Tia
         }
 
         try {
-            return self::attemptBoot(self::$projectRoot, self::$storageMode, self::$resolvers);
+            return self::attemptBoot(
+                self::$projectRoot,
+                self::$storageMode,
+                self::$resolvers,
+                self::$fallbackBranch,
+            );
         } catch (Throwable) {
             // A TIA replay failure must never break the underlying test
             // suite — fall back to letting every test actually run.
@@ -250,8 +276,12 @@ final class Tia
     /**
      * @param  list<Contracts\Resolver>  $resolvers
      */
-    private static function attemptBoot(string $projectRoot, string $storageMode, array $resolvers): self
-    {
+    private static function attemptBoot(
+        string $projectRoot,
+        string $storageMode,
+        array $resolvers,
+        string $fallbackBranch,
+    ): self {
         $state = new FileState(Storage::resolve($projectRoot, $storageMode));
         $raw = $state->read(Storage::GRAPH_KEY);
 
@@ -266,6 +296,7 @@ final class Tia
         }
 
         $graph->setResolvers($resolvers);
+        $graph->setFallbackBranch($fallbackBranch);
 
         $current = Fingerprint::compute($projectRoot);
 

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -166,15 +166,83 @@ final class GraphTest extends TestCase
     }
 
     #[Test]
-    public function get_result_falls_back_to_the_fallback_branch(): void
+    public function get_result_falls_back_to_main_by_default(): void
     {
         $graph = $this->graph();
         $graph->setResult('main', 'Tests\\FooTest::it_works', 0, '', 0.0);
 
-        $status = $graph->getResult('feature/x', 'Tests\\FooTest::it_works', fallbackBranch: 'main');
+        $status = $graph->getResult('feature/x', 'Tests\\FooTest::it_works');
 
         $this->assertNotNull($status);
         $this->assertTrue($status->isSuccess());
+    }
+
+    #[Test]
+    public function get_result_falls_back_to_a_custom_fallback_branch(): void
+    {
+        $graph = $this->graph();
+        $graph->setFallbackBranch('develop');
+        $graph->setResult('develop', 'Tests\\FooTest::it_works', 0, '', 0.0);
+
+        $status = $graph->getResult('feature/x', 'Tests\\FooTest::it_works');
+
+        $this->assertNotNull($status);
+        $this->assertTrue($status->isSuccess());
+    }
+
+    #[Test]
+    public function all_baseline_reads_support_a_custom_fallback_branch(): void
+    {
+        $this->repo->write('tests/FooTest.php', "<?php\n");
+
+        $graph = $this->graph();
+        $graph->setFallbackBranch('develop');
+        $testId = 'Tests\\FooTest::it_works';
+
+        $graph->setResult('develop', $testId, 0, '', 0.0, 4, 'tests/FooTest.php');
+        $graph->setResult('develop', 'Tests\\FooTest::it_fails', 7, 'failed', 0.0, 0, 'tests/FooTest.php');
+        $graph->setResult('develop', 'Tests\\FooTest::it_is_unlocated', 7, 'failed', 0.0);
+        $graph->setRecordedAtSha('develop', 'develop-sha');
+        $graph->setLastRunTree('develop', ['src/Foo.php' => 'develop-hash']);
+
+        $this->assertTrue($graph->getResult('feature/x', $testId)?->isSuccess());
+        $this->assertSame(4, $graph->getAssertions('feature/x', $testId));
+        $this->assertSame('develop-sha', $graph->recordedAtSha('feature/x'));
+        $this->assertSame(['src/Foo.php' => 'develop-hash'], $graph->lastRunTree('feature/x'));
+        $this->assertSame(['tests/FooTest.php'], $graph->testFilesToRerun('feature/x'));
+        $this->assertTrue($graph->hasUnlocatedTestsToRerun('feature/x'));
+    }
+
+    #[Test]
+    public function an_existing_branch_baseline_takes_precedence_over_a_custom_fallback_branch(): void
+    {
+        $graph = $this->graph();
+        $graph->setFallbackBranch('develop');
+        $testId = 'Tests\\FooTest::it_works';
+
+        $graph->setResult('develop', $testId, 0, '', 0.0);
+        $graph->setRecordedAtSha('develop', 'develop-sha');
+        $graph->setResult('feature/x', $testId, 7, 'failed', 0.0);
+        $graph->setRecordedAtSha('feature/x', 'feature-sha');
+
+        $status = $graph->getResult('feature/x', $testId);
+
+        $this->assertNotNull($status);
+        $this->assertTrue($status->isFailure());
+        $this->assertSame('feature-sha', $graph->recordedAtSha('feature/x'));
+    }
+
+    #[Test]
+    public function baseline_reads_are_empty_when_a_custom_fallback_branch_is_missing(): void
+    {
+        $graph = $this->graph();
+        $graph->setFallbackBranch('develop');
+        $testId = 'Tests\\FooTest::it_works';
+
+        $this->assertNull($graph->getResult('feature/x', $testId));
+        $this->assertNull($graph->getAssertions('feature/x', $testId));
+        $this->assertNull($graph->recordedAtSha('feature/x'));
+        $this->assertSame([], $graph->lastRunTree('feature/x'));
     }
 
     #[Test]

--- a/tests/TiaTest.php
+++ b/tests/TiaTest.php
@@ -153,6 +153,86 @@ final class TiaTest extends TestCase
     }
 
     #[Test]
+    public function it_uses_a_configured_fallback_branch_for_replay(): void
+    {
+        [$class, $method, $sha] = $this->recordPassingTest(baselineBranch: 'develop');
+
+        Tia::configure($this->repo->path(), 'local', fallbackBranch: 'develop');
+        $tia = Tia::instance();
+
+        $status = $tia->cachedStatusIfUnaffected($class, $method);
+
+        $this->assertNotNull($status);
+        $this->assertTrue($status->isSuccess());
+        $this->assertSame(3, $tia->cachedAssertionCount($class, $method));
+        $this->assertSame($sha, $tia->recordedAtSha());
+    }
+
+    /**
+     * Same setup as the test above but for the tree, which is seeded stale —
+     * so the recordedAtSha() assertion is what proves the develop baseline was
+     * found at all (without it, "no baseline anywhere" would produce the same
+     * null status and the test would pass for the wrong reason).
+     */
+    #[Test]
+    public function it_uses_a_configured_fallback_tree_when_filtering_changes(): void
+    {
+        [$class, $method, $sha] = $this->recordPassingTest(
+            baselineBranch: 'develop',
+            lastRunTree: ['src/Foo.php' => 'stale-hash'],
+        );
+
+        Tia::configure($this->repo->path(), 'local', fallbackBranch: 'develop');
+        $tia = Tia::instance();
+
+        $this->assertSame($sha, $tia->recordedAtSha());
+        $this->assertNull($tia->cachedStatusIfUnaffected($class, $method));
+    }
+
+    /**
+     * Extension passes the raw XML parameter through untouched, so trimming
+     * has to happen here or a padded value would never match a baseline key —
+     * silently disabling the fallback with no way to distinguish that from
+     * "the branch genuinely has no baseline".
+     */
+    #[Test]
+    public function it_trims_a_configured_fallback_branch(): void
+    {
+        [$class, $method, $sha] = $this->recordPassingTest(baselineBranch: 'develop');
+
+        Tia::configure($this->repo->path(), 'local', fallbackBranch: '  develop  ');
+        $tia = Tia::instance();
+
+        $status = $tia->cachedStatusIfUnaffected($class, $method);
+
+        $this->assertNotNull($status);
+        $this->assertTrue($status->isSuccess());
+        $this->assertSame($sha, $tia->recordedAtSha());
+    }
+
+    /**
+     * A blank value must degrade to the default branch rather than to a
+     * fallback that can never match. Recorded on main and run from a branch
+     * cut off it, so replaying proves the default was actually substituted —
+     * on main itself the direct baseline hit would mask it.
+     */
+    #[Test]
+    public function it_falls_back_to_the_default_branch_when_configured_blank(): void
+    {
+        [$class, $method, $sha] = $this->recordPassingTest(baselineBranch: 'main');
+        $this->repo->run(['git', 'checkout', '-q', '-b', 'feature/x']);
+
+        Tia::configure($this->repo->path(), 'local', fallbackBranch: '   ');
+        $tia = Tia::instance();
+
+        $status = $tia->cachedStatusIfUnaffected($class, $method);
+
+        $this->assertNotNull($status);
+        $this->assertTrue($status->isSuccess());
+        $this->assertSame($sha, $tia->recordedAtSha());
+    }
+
+    #[Test]
     public function it_does_not_replay_a_test_whose_source_file_changed(): void
     {
         [$class, $method] = $this->recordPassingTest();
@@ -385,16 +465,25 @@ final class TiaTest extends TestCase
     /**
      * @return array{0: string, 1: string, 2: string} [className, methodName, sha]
      */
-    private function recordPassingTest(?string $sha = null, ?array $fingerprint = null): array
-    {
-        return $this->recordTest(TestStatus::success(), $sha, $fingerprint);
+    private function recordPassingTest(
+        ?string $sha = null,
+        ?array $fingerprint = null,
+        string $baselineBranch = 'main',
+        ?array $lastRunTree = null,
+    ): array {
+        return $this->recordTest(TestStatus::success(), $sha, $fingerprint, $baselineBranch, $lastRunTree);
     }
 
     /**
      * @return array{0: string, 1: string, 2: string} [className, methodName, sha]
      */
-    private function recordTest(TestStatus $status, ?string $sha = null, ?array $fingerprint = null): array
-    {
+    private function recordTest(
+        TestStatus $status,
+        ?string $sha = null,
+        ?array $fingerprint = null,
+        string $baselineBranch = 'main',
+        ?array $lastRunTree = null,
+    ): array {
         $this->repo->write('src/Foo.php', "<?php\n\nclass Foo\n{\n}\n");
         $class = $this->defineFixtureClass('tests/FooTest.php', ['test_it_works', 'test_a_different_method_never_run']);
         $method = 'test_it_works';
@@ -403,12 +492,23 @@ final class TiaTest extends TestCase
 
         $graph = new Graph($this->repo->path());
         $graph->link($this->repo->path().'/tests/FooTest.php', $this->repo->path().'/src/Foo.php');
-        $graph->setResult('main', $class.'::'.$method, $status->asInt(), $status->message(), 0.01, 3, 'tests/FooTest.php');
+        $graph->setResult(
+            $baselineBranch,
+            $class.'::'.$method,
+            $status->asInt(),
+            $status->message(),
+            0.01,
+            3,
+            'tests/FooTest.php',
+        );
         $graph->setFingerprint($fingerprint ?? Fingerprint::compute($this->repo->path()));
-        $graph->setRecordedAtSha('main', $sha ?? $recordedSha);
+        $graph->setRecordedAtSha($baselineBranch, $sha ?? $recordedSha);
 
         $changedFiles = new ChangedFiles($this->repo->path());
-        $graph->setLastRunTree('main', $changedFiles->snapshotTree(['src/Foo.php', 'tests/FooTest.php']));
+        $graph->setLastRunTree(
+            $baselineBranch,
+            $lastRunTree ?? $changedFiles->snapshotTree(['src/Foo.php', 'tests/FooTest.php']),
+        );
 
         $state = new FileState(Storage::resolve($this->repo->path(), 'local'));
         $state->write(Storage::GRAPH_KEY, (string) $graph->encode());


### PR DESCRIPTION
This PR makes the fallback branch configurable through `phpunit.xml`:                                                                                                                                                             
                                                                                                                                                                                                                                    
```xml                                                                                                                                                                                                                            
<parameter name="fallback-branch" value="develop"/>
```

Right now it's hardcoded to `main`. That works perfectly if it's where the full test suite actually gets run, but for anyone on `master`, `develop`, or a long-lived feature branch, the fallback silently never triggers. The baseline it points at never exists.

This affects my current situation and is what led me to raising this PR. Every new branch I create from `develop` results in the entire test suite needing to be run, even if I've run the full test suite on `develop` immediately before checking out the new branch.

While I was in there I realised I could remove the `$fallbackBranch = 'main'` parameter from the Graph read methods. Nothing in `src/` ever passed anything different in. The fallback is fixed for a whole run, so it now lives as a private property on `Graph.php`, set once when Tia boots, alongside the existing `setResolvers()`. It felt worth closing this off, as any new callers that forgets the argument silently fallback to `main` again.

These methods are public, so it could technically be classed as a breaking change for anyone calling them from outside the package. Nothing documents them as public API though, I _feel like_ that's a near-zero risk, but happy to revert if you'd rather keep the signatures.


Tests are included!

_p.s. long time follower of your streams! This is my first open source PR, thank you for all you do!_