### PR TITLE
Prune deleted source files from the graph after each run

### DIFF
--- a/src/Graph.php
+++ b/src/Graph.php
@@ -664,6 +664,60 @@ final class Graph
     }
 
     /**
+     * Drop source files that no longer exist on disk, from the file table and
+     * from every edge that pointed at them.
+     *
+     * Edges only ever accumulate (see replaceEdges()), so without this a
+     * deleted source file stays linked to every test that once covered it.
+     * Its snapshot hash can never match again — the file is gone — so
+     * ChangedFiles::filterUnchangedSinceLastRun() reports it changed on
+     * every run, and each of those tests re-runs forever. A widely-used file
+     * (a cast, a base controller) pins most of the suite that way.
+     *
+     * Pruning is safe: the run that first saw the deletion already re-ran the
+     * dependents (the file was still linked when the affected set was
+     * computed), and a file that does not exist cannot be covered again.
+     */
+    public function pruneMissingSources(): void
+    {
+        $root = rtrim($this->projectRoot, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        $keep = [];
+
+        foreach ($this->files as $id => $rel) {
+            if (is_file($root.$rel)) {
+                $keep[$id] = $rel;
+            }
+        }
+
+        if (count($keep) === count($this->files)) {
+            return;
+        }
+
+        $remap = [];
+        $files = [];
+
+        foreach ($keep as $oldId => $rel) {
+            $remap[$oldId] = count($files);
+            $files[] = $rel;
+        }
+
+        foreach ($this->edges as $testRel => $ids) {
+            $mapped = [];
+
+            foreach ($ids as $id) {
+                if (isset($remap[$id])) {
+                    $mapped[] = $remap[$id];
+                }
+            }
+
+            $this->edges[$testRel] = $mapped;
+        }
+
+        $this->files = $files;
+        $this->fileIds = array_flip($files);
+    }
+
+    /**
      * Prune baseline result entries whose test files were just executed but
      * whose test IDs no longer exist in the codebase (e.g. the test method was
      * removed or renamed).

--- a/src/Subscribers/WriteGraph.php
+++ b/src/Subscribers/WriteGraph.php
@@ -85,7 +85,6 @@ final readonly class WriteGraph implements ExecutionFinishedSubscriber
         $graph->markKnownTestFiles($executedTestFiles);
         $graph->pruneStaleResults($branch, $executedTestFiles, $keepTestIds);
         $graph->pruneMissingTests();
-        $graph->pruneMissingSources();
 
         $graph->setFingerprint($currentFingerprint);
 
@@ -94,7 +93,18 @@ final readonly class WriteGraph implements ExecutionFinishedSubscriber
         // advancing the baseline here would "bank" unverified edits as already-seen
         // (see the doc comment on isPartialRun()). Leave both pointers at whatever
         // the last authoritative run left them.
+        //
+        // pruneMissingSources() belongs in this same branch: its safety argument
+        // ("the run that first saw the deletion already re-ran the dependents")
+        // only holds when this run covered the whole tracked file set. On a
+        // filtered/aborted run, a test that solely depended on the now-deleted
+        // file may not have executed yet — pruning its edge here, before an
+        // authoritative run confirms the deletion, would strand that dependent
+        // on the sibling-directory fallback instead of the direct edge, and it
+        // could be missed entirely if nothing else in that directory is covered.
         if (! $this->isPartialRun()) {
+            $graph->pruneMissingSources();
+
             $graph->setRecordedAtSha($branch, $changedFiles->currentSha());
             $graph->setLastRunTree($branch, $changedFiles->snapshotTree(
                 array_values(array_unique([...$graph->allTestFiles(), ...$graph->allSourceFiles()])),

--- a/src/Subscribers/WriteGraph.php
+++ b/src/Subscribers/WriteGraph.php
@@ -85,6 +85,7 @@ final readonly class WriteGraph implements ExecutionFinishedSubscriber
         $graph->markKnownTestFiles($executedTestFiles);
         $graph->pruneStaleResults($branch, $executedTestFiles, $keepTestIds);
         $graph->pruneMissingTests();
+        $graph->pruneMissingSources();
 
         $graph->setFingerprint($currentFingerprint);
 

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -336,6 +336,39 @@ final class GraphTest extends TestCase
     }
 
     #[Test]
+    public function prune_missing_sources_drops_deleted_source_files_and_their_edges(): void
+    {
+        $this->repo->write('src/Foo.php', "<?php\n");
+        $this->repo->write('src/Gone.php', "<?php\n");
+        $this->repo->write('src/Bar.php', "<?php\n");
+        $this->repo->write('tests/FooTest.php', "<?php\n");
+        $this->repo->write('tests/BarTest.php', "<?php\n");
+
+        $graph = $this->graph();
+        $graph->link('tests/FooTest.php', 'src/Foo.php');
+        $graph->link('tests/FooTest.php', 'src/Gone.php');
+        $graph->link('tests/BarTest.php', 'src/Gone.php');
+        $graph->link('tests/BarTest.php', 'src/Bar.php');
+
+        unlink($this->repo->path().'/src/Gone.php');
+
+        $graph->pruneMissingSources();
+
+        $this->assertSame(['src/Foo.php', 'src/Bar.php'], $graph->allSourceFiles());
+        $this->assertSame(['tests/FooTest.php'], $graph->affected(['src/Foo.php']));
+        $this->assertSame(['tests/BarTest.php'], $graph->affected(['src/Bar.php']));
+        // The deleted file is now unknown to the graph, so a change to it is
+        // resolved through the sibling-directory fallback, not a stale edge.
+        $reasons = [];
+        $graph->affected(['src/Gone.php'], $reasons);
+        $this->assertStringContainsString('shares a directory', $reasons['tests/FooTest.php']);
+
+        // Ids were remapped, so a re-link of a surviving file reuses its slot.
+        $graph->link('tests/BarTest.php', 'src/Foo.php');
+        $this->assertSame(['src/Foo.php', 'src/Bar.php'], $graph->allSourceFiles());
+    }
+
+    #[Test]
     public function prune_stale_results_drops_results_for_removed_test_methods(): void
     {
         $this->repo->write('tests/FooTest.php', "<?php\n");

--- a/tests/WriteGraphTest.php
+++ b/tests/WriteGraphTest.php
@@ -274,6 +274,60 @@ final class WriteGraphTest extends TestCase
     }
 
     /**
+     * A full, unnarrowed run is the only kind that's authoritative for "every
+     * dependent of a deleted source has already been re-run" — see
+     * WriteGraph::notify()'s doc comment on why pruneMissingSources() shares
+     * the isPartialRun() gate with the baseline advancement above it.
+     */
+    #[Test]
+    public function it_prunes_a_deleted_source_file_on_a_full_run(): void
+    {
+        $testId = self::class.'::it_prunes_a_deleted_source_file_on_a_full_run';
+        $this->seedGraphWithDeletableSource($testId);
+
+        $this->notify($this->resultsFor($testId));
+
+        $this->assertNotContains('src/Gone.php', $this->persistedGraph()->allSourceFiles());
+    }
+
+    /**
+     * On a narrowed run, a test that solely depended on the deleted file may
+     * not have executed yet — pruning here would strand it on the
+     * sibling-directory fallback (or miss it outright) once a later full run
+     * tries to resolve the deletion.
+     *
+     * @param  list<string>  $cliArguments
+     */
+    #[Test]
+    #[DataProvider('narrowingCliArguments')]
+    public function it_leaves_a_deleted_source_file_alone_on_a_narrowed_run(array $cliArguments): void
+    {
+        $testId = self::class.'::it_leaves_a_deleted_source_file_alone_on_a_narrowed_run';
+        $this->seedGraphWithDeletableSource($testId);
+
+        $this->notify($this->resultsFor($testId), cliArguments: $cliArguments);
+
+        $this->assertContains('src/Gone.php', $this->persistedGraph()->allSourceFiles());
+    }
+
+    private function seedGraphWithDeletableSource(string $testId): void
+    {
+        $this->repo->write('src/Foo.php', "<?php\n");
+        $this->repo->write('src/Gone.php', "<?php\n");
+        $this->repo->write('tests/FooTest.php', "<?php\n");
+        $this->repo->commit('seed');
+
+        $graph = new Graph($this->repo->path());
+        $graph->link('tests/FooTest.php', 'src/Gone.php');
+        $graph->setFingerprint(Fingerprint::compute($this->repo->path()));
+        $graph->setRecordedAtSha('main', (new ChangedFiles($this->repo->path()))->currentSha());
+
+        $this->state()->write(Storage::GRAPH_KEY, (string) $graph->encode());
+
+        unlink($this->repo->path().'/src/Gone.php');
+    }
+
+    /**
      * Seeds a baseline, stamps it with a recorded sha and a tree snapshot, then
      * commits an unrelated edit after that — the point a full run's baseline
      * would legitimately move past, and a narrowed/aborted run's must not.


### PR DESCRIPTION
## Problem

Edges only accumulate (`replaceEdges()` merges, per #7), so a deleted source file stays linked to every test that once covered it. Its snapshot hash can never match again, so `ChangedFiles::filterUnchangedSinceLastRun()` reports it as changed on every run, and every one of those tests re-runs forever.

Observed on a Laravel app: a removed cast class had been covered by 86 test files. With a clean working tree and the baseline at HEAD, every run re-executed 1231 of 1772 tests (about 4 minutes instead of 6 seconds). `PHPUNIT_TIA_FRESH=1` clears it, but it comes back with the next deletion.

Repro from the graph: `files` still contained the three deleted paths, `filterUnchangedSinceLastRun()` returned them every run (current hash `null` vs snapshot), and `affected()` matched them through their stale edges.

## Fix

`Graph::pruneMissingSources()` drops source files that no longer exist on disk from the file table and from every edge, remapping ids. `WriteGraph` calls it next to `pruneMissingTests()`.

This loses nothing: the run that first saw the deletion already re-ran the dependents (the file was still linked when the affected set was computed), and a file that does not exist cannot be covered again. A later change under the same path is resolved by the sibling-directory fallback, which the added test asserts.

Suite and pint pass.